### PR TITLE
[slackana-05] - [Markup] User Sign In Page

### DIFF
--- a/client/src/components/AuthForm.tsx
+++ b/client/src/components/AuthForm.tsx
@@ -1,0 +1,100 @@
+import React, { FC } from 'react'
+import { useForm } from 'react-hook-form'
+import { yupResolver } from '@hookform/resolvers/yup'
+
+import { styles } from '~/shared/twin/auth.styles'
+import { SignInUpFormValues } from '~/shared/types'
+import { Spinner } from '~/shared/icons/SpinnerIcon'
+import { globals } from '~/shared/twin/globals.styles'
+import { SignInFormSchema, SignUpFormSchema } from '~/shared/validation'
+
+type Props = {
+  isLogin: boolean
+  actions: {
+    handleAuthSubmit: (data: SignInUpFormValues) => Promise<void>
+  }
+}
+
+const AuthForm: FC<Props> = (props): JSX.Element => {
+  const {
+    isLogin,
+    actions: { handleAuthSubmit }
+  } = props
+
+  const {
+    register,
+    handleSubmit,
+    formState: { isSubmitting, errors }
+  } = useForm<SignInUpFormValues>({
+    mode: 'onTouched',
+    resolver: yupResolver(isLogin ? SignInFormSchema : SignUpFormSchema)
+  })
+
+  return (
+    <form css={styles.form} onSubmit={handleSubmit(handleAuthSubmit)}>
+      {!isLogin && (
+        <div>
+          <label htmlFor="name" css={globals.form_label}>
+            Name <span>*</span>
+          </label>
+          <input
+            type="text"
+            css={globals.form_control}
+            disabled={isSubmitting}
+            placeholder="john doe"
+            {...register('name')}
+          />
+          {errors?.name && <span className="error">{`${errors?.name?.message}`}</span>}
+        </div>
+      )}
+      <div>
+        <label htmlFor="email" css={globals.form_label}>
+          Email address <span>*</span>
+        </label>
+        <input
+          type="email"
+          css={globals.form_control}
+          disabled={isSubmitting}
+          placeholder="name@company.com"
+          {...register('email')}
+        />
+        {errors?.email && <span className="error">{`${errors?.email?.message}`}</span>}
+      </div>
+      <div>
+        <label htmlFor="password" css={globals.form_label}>
+          Password <span>*</span>
+        </label>
+        <input
+          type="password"
+          css={globals.form_control}
+          disabled={isSubmitting}
+          placeholder="•••••••••"
+          {...register('password')}
+        />
+        {errors?.password && <span className="error">{`${errors?.password?.message}`}</span>}
+      </div>
+      {!isLogin && (
+        <div>
+          <label htmlFor="confirm_password" css={globals.form_label}>
+            Confirm password <span>*</span>
+          </label>
+          <input
+            type="password"
+            css={globals.form_control}
+            disabled={isSubmitting}
+            placeholder="•••••••••"
+            {...register('confirm_password')}
+          />
+          {errors?.confirm_password && (
+            <span className="error">{`${errors?.confirm_password?.message}`}</span>
+          )}
+        </div>
+      )}
+      <button type="submit" css={styles.form_submit} disabled={isSubmitting}>
+        {isSubmitting ? <Spinner className="h-5 w-5" /> : 'Continue'}
+      </button>
+    </form>
+  )
+}
+
+export default AuthForm

--- a/client/src/layouts/AuthLayout.tsx
+++ b/client/src/layouts/AuthLayout.tsx
@@ -1,0 +1,56 @@
+import Link from 'next/link'
+import Head from 'next/head'
+import { useRouter } from 'next/router'
+import React, { FC, ReactNode } from 'react'
+
+import Logo2Icon from '~/shared/icons/Logo2Icon'
+import GoogleIcon from '~/shared/icons/GoogleIcon'
+import { styles } from '~/shared/twin/auth.styles'
+
+type Props = {
+  children: ReactNode
+  metaTitle: string
+}
+
+const AuthLayout: FC<Props> = ({ children, metaTitle }): JSX.Element => {
+  const router = useRouter()
+
+  const isSignUp = router.pathname === '/sign-up'
+
+  return (
+    <>
+      <Head>
+        <title key={metaTitle}>Slackana | {metaTitle}</title>
+      </Head>
+      <main css={styles.main}>
+        <section css={styles.section}>
+          <nav css={styles.nav}>
+            <div css={styles.business_logo}>
+              <Logo2Icon />
+              <h1>Slackana</h1>
+            </div>
+            <div css={styles.google_provider}>
+              <h1>{isSignUp ? 'Sign Up' : 'Sign In'} to Slackana</h1>
+              <button type="button" className="focus:outline-blue-600">
+                <GoogleIcon />
+                <span>Continue with Google</span>
+              </button>
+              <div css={styles.or}>
+                <span>or</span>
+              </div>
+            </div>
+          </nav>
+          {children}
+          <footer css={styles.footer}>
+            <span>{isSignUp ? 'Do you have an account?' : "You don't have an account?"}</span>
+            <Link href={isSignUp ? '/sign-in' : '/sign-up'}>
+              <a>{isSignUp ? 'Sign In' : 'Sign Up'}</a>
+            </Link>
+          </footer>
+        </section>
+      </main>
+    </>
+  )
+}
+
+export default AuthLayout

--- a/client/src/pages/sign-in.tsx
+++ b/client/src/pages/sign-in.tsx
@@ -1,8 +1,28 @@
 import React from 'react'
 import { NextPage } from 'next'
+import { useRouter } from 'next/router'
+
+import AuthForm from '~/components/AuthForm'
+import AuthLayout from '~/layouts/AuthLayout'
+import { SignInUpFormValues } from '~/shared/types'
 
 const SignIn: NextPage = (): JSX.Element => {
-  return <div>sign-in</div>
+  const router = useRouter()
+
+  const handleAuthSubmit = async (data: SignInUpFormValues): Promise<void> => {
+    return new Promise((resolve) => {
+      setTimeout(() => {
+        resolve()
+        router.push('/')
+      }, 3000)
+    })
+  }
+
+  return (
+    <AuthLayout metaTitle="Sign In">
+      <AuthForm actions={{ handleAuthSubmit }} isLogin />
+    </AuthLayout>
+  )
 }
 
 export default SignIn

--- a/client/src/pages/sign-up.tsx
+++ b/client/src/pages/sign-up.tsx
@@ -1,31 +1,15 @@
 import React from 'react'
-import Head from 'next/head'
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
-import { useForm } from 'react-hook-form'
-import { yupResolver } from '@hookform/resolvers/yup'
 
-import Logo2Icon from '~/shared/icons/Logo2Icon'
-import GoogleIcon from '~/shared/icons/GoogleIcon'
-import { styles } from '~/shared/twin/auth.styles'
+import AuthForm from '~/components/AuthForm'
+import AuthLayout from '~/layouts/AuthLayout'
 import { SignInUpFormValues } from '~/shared/types'
-import { Spinner } from '~/shared/icons/SpinnerIcon'
-import { globals } from '~/shared/twin/globals.styles'
-import { SignUpFormSchema } from '~/shared/validation'
 
 const SignUp: NextPage = (): JSX.Element => {
   const router = useRouter()
 
-  const {
-    register,
-    handleSubmit,
-    formState: { isSubmitting, errors }
-  } = useForm<Partial<SignInUpFormValues>>({
-    mode: 'onTouched',
-    resolver: yupResolver(SignUpFormSchema)
-  })
-
-  const handleSignUp = async (): Promise<void> => {
+  const handleAuthSubmit = async (data: SignInUpFormValues): Promise<void> => {
     return new Promise((resolve) => {
       setTimeout(() => {
         resolve()
@@ -35,96 +19,9 @@ const SignUp: NextPage = (): JSX.Element => {
   }
 
   return (
-    <>
-      <Head>
-        <title>Slackana | Sign Up</title>
-      </Head>
-      <main css={styles.main}>
-        <section css={styles.section}>
-          <nav css={styles.nav}>
-            <div css={styles.business_logo}>
-              <Logo2Icon />
-              <h1>Slackana</h1>
-            </div>
-            <div css={styles.google_provider}>
-              <h1>Sign Up to Slackana</h1>
-              <button type="button" className="focus:outline-blue-600">
-                <GoogleIcon />
-                <span>Continue with Google</span>
-              </button>
-              <div css={styles.or}>
-                <span>or</span>
-              </div>
-            </div>
-          </nav>
-          <form css={styles.form} onSubmit={handleSubmit(handleSignUp)}>
-            <div>
-              <label htmlFor="name" css={globals.form_label}>
-                Name <span>*</span>
-              </label>
-              <input
-                type="text"
-                css={globals.form_control}
-                disabled={isSubmitting}
-                placeholder="john doe"
-                {...register('name')}
-              />
-              {errors?.name && <span className="error">{`${errors?.name?.message}`}</span>}
-            </div>
-            <div>
-              <label htmlFor="email" css={globals.form_label}>
-                Email address <span>*</span>
-              </label>
-              <input
-                type="email"
-                css={globals.form_control}
-                disabled={isSubmitting}
-                placeholder="name@company.com"
-                {...register('email')}
-              />
-              {errors?.email && <span className="error">{`${errors?.email?.message}`}</span>}
-            </div>
-            <div>
-              <label htmlFor="password" css={globals.form_label}>
-                Password <span>*</span>
-              </label>
-              <input
-                type="password"
-                css={globals.form_control}
-                disabled={isSubmitting}
-                placeholder="•••••••••"
-                {...register('password')}
-              />
-              {errors?.password && <span className="error">{`${errors?.password?.message}`}</span>}
-            </div>
-            <div>
-              <label htmlFor="confirm_password" css={globals.form_label}>
-                Confirm password <span>*</span>
-              </label>
-              <input
-                type="password"
-                css={globals.form_control}
-                disabled={isSubmitting}
-                placeholder="•••••••••"
-                {...register('confirm_password')}
-              />
-              {errors?.confirm_password && (
-                <span className="error">{`${errors?.confirm_password?.message}`}</span>
-              )}
-            </div>
-            <div className="pt-4">
-              <button type="submit" css={styles.form_submit} disabled={isSubmitting}>
-                {isSubmitting ? <Spinner className="h-5 w-5" /> : 'Continue'}
-              </button>
-            </div>
-          </form>
-          <footer css={styles.footer}>
-            <span>Already have an account?</span>
-            <a href="#">Sign In</a>
-          </footer>
-        </section>
-      </main>
-    </>
+    <AuthLayout metaTitle="Sign Up">
+      <AuthForm actions={{ handleAuthSubmit }} isLogin={false} />
+    </AuthLayout>
   )
 }
 

--- a/client/src/shared/twin/globals.styles.ts
+++ b/client/src/shared/twin/globals.styles.ts
@@ -11,6 +11,7 @@ export const globals = {
     tw`block w-full rounded border-none px-3 py-2`,
     tw`text-sm placeholder:text-[#94a3b8] text-[#0f172a]`,
     tw`ring-1 ring-[#cbd5e1] transition duration-150 ease-in-out hover:ring-2`,
-    tw`hover:ring-blue-600 focus:ring-2 focus:ring-blue-600 disabled:opacity-50`
+    tw`hover:ring-blue-600 focus:ring-2 focus:ring-blue-600 disabled:opacity-50`,
+    tw`disabled:hover:ring-2`
   ]
 }

--- a/client/src/shared/validation/index.ts
+++ b/client/src/shared/validation/index.ts
@@ -1,11 +1,16 @@
 import * as Yup from 'yup'
 
+export const SignInFormSchema = Yup.object().shape({
+  email: Yup.string().email().required().label('Email'),
+  password: Yup.string().required('Password is required')
+})
+
 export const SignUpFormSchema = Yup.object().shape({
   name: Yup.string()
     .required('Name is required')
     .min(2, 'Should have atleast 2 characters')
     .max(30, 'Should have max length of 30 characters'),
-  email: Yup.string().email('Email must be valid email').required('Email is required'),
+  email: Yup.string().email().required().label('Email'),
   password: Yup.string()
     .required('Password is required')
     .min(4, 'Password length should be at least 4 characters')


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1202992352418408/1202994363620475/f

## Definition of Done
- [x] Created `AuthLayout` for both `sign-in` and `sign-up`
- [x] Created `AuthForm` for both `sign-in` and `sign-up` form fields 
- [x] Reused both `AuthLayout` and `AuthForm` components inside each pages 
- [x] Handled validation both  `sign-in` and `sign-up` form 
- [x] Had a loading indicator when the button is clicked with disabled form fields  

## Notes
- It can get form data from each page dynamically

Figma design: https://www.figma.com/file/RPsCfeJOXri9iYh3eOf1G6/Slackana?node-id=481%3A902

## Pre-condition
cli: `cd client`
- yarn dev || npm run dev
- Go to `/sign-in` page to view the design

## Expected Output
- Can validate both `sign-in` and `sign-up` page

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/108642414/192133061-d10fb5de-1359-4e1f-b7e3-e093e87068f8.png)



