### PR TITLE
[slackana]-54 [Bugtask] Fix Filter Dropdown is not Responsive

### DIFF
--- a/client/src/components/molecules/UserMenuDropdown/index.tsx
+++ b/client/src/components/molecules/UserMenuDropdown/index.tsx
@@ -8,7 +8,7 @@ import MenuTransition from '~/components/templates/MenuTransition'
 
 const UserMenuDropDown: FC = (): JSX.Element => {
   return (
-    <Menu as="div" className="relative inline-block text-left">
+    <Menu as="div" className="relative z-10 inline-block text-left">
       <Menu.Button css={globals.avatar}>
         <img src="/images/animated-avatar.jpg" />
       </Menu.Button>


### PR DESCRIPTION
## Issue Link
-  https://app.asana.com/0/1203011167276287/1203087258981547/f

## Definition of Done
- [x] Add utility `z-10` in the UserMenuDropdown

## Notes 
- Issue #24 

## Pre-condition
- yarn

## Expected Output
- The UserMenuDropdown will show full content in the mobile device

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/108642414/193489971-ef4e684f-3fd0-4f32-ba72-418192664050.png)
