### PR TITLE
[slackana-55] - [Bugtask] Remove excess Padding in Add Member Modal Header

### DIFF
--- a/client/src/components/organisms/AddMemberModal/index.tsx
+++ b/client/src/components/organisms/AddMemberModal/index.tsx
@@ -25,7 +25,7 @@ const AddMemberModal = ({ close }: { close: (value: boolean) => void }) => {
   }
 
   const addPeopleComponent = (
-    <DialogBox hasMenu={true} isOpen={true} closeModal={() => setAddPeopleModal(!addPeopleModal)} headerTitle="Add people" bodyClass="!px-0 !pb-0 mobile:!px-0">
+    <DialogBox isOpen={true} closeModal={() => setAddPeopleModal(!addPeopleModal)} headerTitle="Add people" bodyClass="!px-0 !pb-0 mobile:!px-0 !pt-0">
       <div className="flex flex-col">
         <div className="mt-3 flex items-center justify-between border-b pb-3 px-6">
           <div className="w-full flex flex-row border border-slate-300 items-center pl-2 rounded-md">
@@ -44,7 +44,7 @@ const AddMemberModal = ({ close }: { close: (value: boolean) => void }) => {
   );
 
   return (
-    <DialogBox hasMenu={true} isOpen={true} closeModal={() => close(false)} headerTitle="Add member" bodyClass="!px-0 !pb-0 mobile:!px-0">
+    <DialogBox isOpen={true} closeModal={() => close(false)} headerTitle="Add member" bodyClass="!px-0 !pb-0 mobile:!px-0 !pt-0">
       {addPeopleModal && addPeopleComponent}
       <div className="flex flex-col">
         <div className="mt-3 flex items-center justify-between border-b pb-3 px-6">


### PR DESCRIPTION
## Issue Link
-  https://app.asana.com/0/1203011167276287/1203087606665259/f

## Definition of Done
- [x] There is no excess padding below the modal header title

## Notes 
- (Optional)

## Pre-condition
- yarn

## Expected Output
- There should be no excess padding below the header title in add member and add people modal

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/193542525-23675623-7113-465b-b287-e6b6afa4dbce.png)
![image](https://user-images.githubusercontent.com/104751512/193542536-44b39088-c9de-4394-9ee8-b05f08802578.png)
