### PR TITLE
[slackana-07] -[FE] Implement Route Protection

### DIFF
--- a/client/src/pages/team/[id]/board.tsx
+++ b/client/src/pages/team/[id]/board.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 
 import { classNames } from '~/helpers/classNames'
 import ProjectLayout from '~/components/templates/ProjectLayout'
+import UnderContruction from '~/utils/UnderContruction'
 
 const Board: FC = (): JSX.Element => {
   const router = useRouter()
@@ -17,10 +18,11 @@ const Board: FC = (): JSX.Element => {
           'scrollbar-thin scrollbar-track-rounded-full'
         )}
       >
-        This is the board {id}
+        <UnderContruction/>
       </div>
     </ProjectLayout>
   )
 }
 
+export { authCheck as getServerSideProps } from '~/utils/getServerSideProps'
 export default Board

--- a/client/src/pages/team/[id]/chat.tsx
+++ b/client/src/pages/team/[id]/chat.tsx
@@ -3,6 +3,7 @@ import { useRouter } from 'next/router'
 
 import { classNames } from '~/helpers/classNames'
 import ProjectLayout from '~/components/templates/ProjectLayout'
+import UnderContruction from '~/utils/UnderContruction'
 
 const Chat: FC = (): JSX.Element => {
   const router = useRouter()
@@ -17,10 +18,11 @@ const Chat: FC = (): JSX.Element => {
           'scrollbar-thin scrollbar-track-rounded-full'
         )}
       >
-        This is the overview {id}
+        <UnderContruction/>
       </div>
     </ProjectLayout>
   )
 }
 
+export { authCheck as getServerSideProps } from '~/utils/getServerSideProps'
 export default Chat

--- a/client/src/pages/team/[id]/overview.tsx
+++ b/client/src/pages/team/[id]/overview.tsx
@@ -138,4 +138,5 @@ const Overview: FC = (): JSX.Element => {
   )
 }
 
+export { authCheck as getServerSideProps } from '~/utils/getServerSideProps'
 export default Overview


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203026696022122/f

## Definition of Done
- [x] Used `getServerSideProps` as mean to protect the routes in the app

## Notes
- Changed the default view in the board and chat pages

## Pre-condition
- If a user is signed-in
- If a user is not signed-in

## Expected Output
- A signed in user cannot redirect back to the sign-in and sign-up page
- A not authorized user cannot access pages such as the home, board and chat

## Screenshot/Recordings
- Route Protection Demo
 
[route-proection-demo](https://user-images.githubusercontent.com/108660012/193617819-a796f092-e863-4bc4-8765-80ea17ca0525.webm)

- Board Default View

![default-view](https://user-images.githubusercontent.com/108660012/193618116-5885e10b-b714-4603-8383-534a2c4baec1.png)
