### PR TITLE
[slackana-57] - [Markup] Sidebar Persisted State

### DIFF
--- a/client/src/components/organisms/Sidebar/index.tsx
+++ b/client/src/components/organisms/Sidebar/index.tsx
@@ -10,11 +10,11 @@ import Logo2Icon from '~/shared/icons/Logo2Icon'
 import { classNames } from '~/helpers/classNames'
 import { styles } from '~/shared/twin/sidebar.styles'
 import { globals } from '~/shared/twin/globals.styles'
-import UserMenuPopover from '~/components/molecules/UserMenuPopover'
 import { useAppSelector } from '~/hooks/reduxSelector'
+import UserMenuPopover from '~/components/molecules/UserMenuPopover'
 
 type Props = {
-  isOpenSidebar: ConstrainBoolean
+  isOpenSidebar: boolean
 }
 
 const Sidebar: FC<Props> = ({ isOpenSidebar }): JSX.Element => {
@@ -28,9 +28,9 @@ const Sidebar: FC<Props> = ({ isOpenSidebar }): JSX.Element => {
   return (
     <aside
       css={styles.aside}
-      className={classNames(
+      className={
         isOpenSidebar ? 'max-w-0 translate-x-0 md:max-w-[280px]' : 'max-w-0 -translate-x-full'
-      )}
+      }
     >
       <div css={styles.wrapper}>
         <header css={styles.business_logo}>

--- a/client/src/components/templates/HomeLayout/index.tsx
+++ b/client/src/components/templates/HomeLayout/index.tsx
@@ -1,18 +1,23 @@
 import Head from 'next/head'
+import dynamic from 'next/dynamic'
 import React, { useState } from 'react'
+import createPersistedState from 'use-persisted-state'
 
 import Drawer from '~/components/organisms/Drawer'
 import Header from '~/components/organisms/Header'
-import Sidebar from '~/components/organisms/Sidebar'
 import { styles } from '~/shared/twin/home-layout.styles'
+
+const Sidebar = dynamic(() => import('~/components/organisms/Sidebar'), { ssr: false })
 
 type Props = {
   children: React.ReactNode
   metaTitle: string
 }
 
+const useSidebarState = createPersistedState<boolean>('sidebarToggle')
+
 const Layout: React.FC<Props> = ({ children, metaTitle }): JSX.Element => {
-  const [isOpenSidebar, setIsOpenSidebar] = useState<boolean>(true)
+  const [isOpenSidebar, setIsOpenSidebar] = useSidebarState(true)
   const [isOpenDrawer, setIsOpenDrawer] = useState<boolean>(false)
 
   const handleToggleSidebar = (): void => setIsOpenSidebar(!isOpenSidebar)


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203087606665269/f

## Definition of Done
- [x] Add `use-persisted-state` to persist the sidebar open and close toggle
- [x] Auto persist every page reload

## Notes
Issue: #29 

## Pre-condition
- Go to the home page

## Expected Output
- Whenever user wants to close the sidebar and click to other route it will persist the state into the localstorage built in `use-persisted-state` npm package

## Screenshot/Recordings
![here](https://user-images.githubusercontent.com/108642414/193724226-3bf47195-81d9-4cd3-b28d-ddbf0beea547.gif)
