### PR TITLE
[slackana-43] - [FE] Integrate Edit Functionality to Overview Page

### DIFF
--- a/client/src/shared/jsons/projectStatusData.ts
+++ b/client/src/shared/jsons/projectStatusData.ts
@@ -1,9 +1,9 @@
 export const projectStatusData: Required<string[]> = [
   'All',
-  'Archive',
   'On track',
   'At risk',
   'Off track',
   'On hold',
   'Complete',
+  'Archive',
 ];


### PR DESCRIPTION
## Issue Link
-  https://app.asana.com/0/1203011167276287/1203026696603986/f

## Definition of Done
- [x] User can edit the project name on the overview page
- [x] User can edit the project status

## Pre-condition
- yarn

## Expected Output
- When the user clicks the team icon, a popup with rename and delete options should show.
- When the user clicks the rename button a modal will pop up containing the current name of the team.
- When the user changes the current name of the team, it should refresh the state and after the refresh, the new name should appear.
- When the user changes the name of the team and the user closed the modal without submitting. The name should not be changed to the unchanged new name.

## Screenshots/Recordings
- Rename
![image](https://user-images.githubusercontent.com/104751512/194733838-f60934aa-fa77-4158-8b8c-55bf056f3134.png)
- Rename modal
![image](https://user-images.githubusercontent.com/104751512/194733842-57fd9a8a-5631-4c36-b3e7-bdfe1099ac06.png)
- Save changes
![image](https://user-images.githubusercontent.com/104751512/194733858-0da9df6e-2ae5-4b8c-81c6-386e7f52e6d4.png)
- View saved changes
![image](https://user-images.githubusercontent.com/104751512/194733854-984fe348-a085-45ee-889e-d40768abe834.png)
- Rename but not saving the changes
![image](https://user-images.githubusercontent.com/104751512/194733866-3d7334e2-51b6-476d-a4ab-cfcd38605f72.png)
- The new name should not be applied when not saved
![image](https://user-images.githubusercontent.com/104751512/194733898-7d29e656-a5c0-447e-8504-50ee369b8c1a.png)
