### PR TITLE
[slackana-17] - [FE] Integrate Filter Projects Functionality

### DIFF
--- a/client/src/components/atoms/SubmitButton/index.tsx
+++ b/client/src/components/atoms/SubmitButton/index.tsx
@@ -1,4 +1,5 @@
 import React from "react";
+
 import { Spinner } from "~/shared/icons/SpinnerIcon";
 import { styles } from '~/shared/twin/auth.styles'
 
@@ -7,11 +8,18 @@ type Props = {
   isSubmitting: boolean;
   text?: string;
   className?: string;
+  isDisabled?: boolean;
 }
 
-const SubmitButton: React.FC<Props> = ({ submitted, isSubmitting, text = "Submit", className = "" }) => {
+const SubmitButton: React.FC<Props> = ({ submitted, isSubmitting, text = "Submit", className = "", isDisabled }) => {
   return (
-    <button onClick={submitted} type="submit" css={styles.form_submit} disabled={isSubmitting} className={className}>
+    <button
+      type="submit"
+      onClick={submitted}
+      css={styles.form_submit}
+      className={`${isDisabled && "!cursor-not-allowed"} ${className}`}
+      disabled={isSubmitting || isDisabled}
+    >
       {isSubmitting ? <Spinner className="h-5 w-5" /> : text}
     </button>
   );

--- a/client/src/redux/project/projectService.ts
+++ b/client/src/redux/project/projectService.ts
@@ -1,0 +1,116 @@
+import { axios } from '~/shared/lib/axios';
+
+const filterProjects = async (params: number): Promise<any> => {
+  const response = await axios.get(`/api/project?filter=${params}`);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const getSidebarProjects = async (): Promise<any> => {
+  const response = await axios.get('/api/project');
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const getProject = async (id: any): Promise<any> => {
+  const response = await axios.get(`/api/project/${id}`);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const createProject = async (project: any): Promise<any> => {
+  const response = await axios.post('/api/project', project);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const renameTeamData = async (teamData: any): Promise<any> => {
+  const { projectID, teamID, name } = teamData;
+
+  const response = await axios.put(`/api/project/${projectID}/team/${teamID}`, { name });
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const updateProjectDetails = async (projectData: any): Promise<any> => {
+  const { id } = projectData;
+
+  const response = await axios.put(`/api/project/${id}`, projectData);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const addNewTeam = async (overviewTeamData: any): Promise<any> => {
+  const { projectID, teamData } = overviewTeamData;
+
+  const response = await axios.post(`/api/project/${projectID}/team`, { teams: teamData.map((team: any) => { return { name: team } }) });
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const removeTeam = async (teamData: any): Promise<any> => {
+  const { projectID, teamID } = teamData;
+
+  const response = await axios.delete(`/api/project/${projectID}/team/${teamID}`);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const archiveProject = async (id: any): Promise<any> => {
+  const response = await axios.delete(`/api/project/${id}/archive`);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const unarchiveProject = async (id: any): Promise<any> => {
+  const response = await axios.put(`/api/project/${id}/un-archive`);
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+const updateProjectStatus = async (statusData: any): Promise<any> => {
+  const { projectID, status } = statusData;
+
+  const response = await axios.put(`/api/project/${projectID}/project-status`, { status });
+
+  if (response.status === 200) {
+    return response.data;
+  }
+  return "Something went wrong"
+};
+
+const projectService = {
+  getProject,
+  addNewTeam,
+  removeTeam,
+  createProject,
+  filterProjects,
+  renameTeamData,
+  archiveProject,
+  unarchiveProject,
+  getSidebarProjects,
+  updateProjectStatus,
+  updateProjectDetails,
+};
+
+export default projectService

--- a/client/src/redux/project/projectSlice.ts
+++ b/client/src/redux/project/projectSlice.ts
@@ -1,0 +1,529 @@
+import {
+  createSlice,
+  createAsyncThunk,
+  ActionReducerMapBuilder,
+  PayloadAction
+} from '@reduxjs/toolkit'
+
+import { Project, AxiosResponseError } from '~/shared/types'
+import { catchError } from '~/utils/handleAxiosError'
+import projectService from './projectService'
+
+type InitialState = {
+  project: Project | null
+  sidebarProject: any
+  overviewProject: Project | null
+  newProject: {
+    title: string,
+    description: string,
+    teams: any
+  }
+  renameTeamData: {
+    projectID: number,
+    teamID: number,
+    name: string
+  }
+  addNewTeam: {
+    projectID: number,
+    teamData: any
+  }
+  removeTeam: {
+    projectID: number,
+    teamID: number
+  }
+  projectDescription: {
+    id: number,
+    title: string,
+    description: string
+  }
+  refresher: {
+    teamStateUpdate: boolean,
+    memberStateUpdate: boolean,
+    projectStateUpdate: boolean,
+  }
+  update: {
+    status: number,
+    projectID: number,
+  }
+  filter: number
+  isError: boolean
+  isSuccess: boolean
+  isLoading: boolean
+  error: AxiosResponseError
+};
+
+const initialState: InitialState = {
+  project: null,
+  sidebarProject: null,
+  newProject: {
+    title: "",
+    description: "",
+    teams: [
+      { name: "Frontend" },
+      { name: "Backend" }
+    ]
+  },
+  overviewProject: {
+    teams: []
+  },
+  renameTeamData: {
+    projectID: 0,
+    teamID: 0,
+    name: ""
+  },
+  addNewTeam: {
+    projectID: 0,
+    teamData: []
+  },
+  removeTeam: {
+    projectID: 0,
+    teamID: 0
+  },
+  projectDescription: {
+    id: 0,
+    title: "",
+    description: ""
+  },
+  refresher: {
+    teamStateUpdate: true,
+    memberStateUpdate: true,
+    projectStateUpdate: true,
+  },
+  update: {
+    status: 0,
+    projectID: 0,
+  },
+  filter: 0,
+  isError: false,
+  isSuccess: false,
+  isLoading: false,
+  error: {
+    status: 0,
+    content: null
+  }
+};
+
+export const getSidebarProjects = createAsyncThunk(
+  'project/sidebarProjectsStatus',
+  async (_, thunkAPI) => {
+    try {
+      return await projectService.getSidebarProjects();
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const filterProjects = createAsyncThunk(
+  'project/filterProjectStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+
+    try {
+      return await projectService.filterProjects(project.filter);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const getProject = createAsyncThunk(
+  'project/getProjectStatus',
+  async (id: any, thunkAPI) => {
+    try {
+      return await projectService.getProject(id)
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const createProject = createAsyncThunk(
+  'project/createProjectStatus',
+  async (project: any, thunkAPI) => {
+    try {
+      return await projectService.createProject(project);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const renameTeamData = createAsyncThunk(
+  'project/renameTeamDataStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+
+    try {
+      return await projectService.renameTeamData(project.renameTeamData);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const updateProjectDetails = createAsyncThunk(
+  'project/updateProjectDetailsStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+
+    try {
+      return await projectService.updateProjectDetails(project.projectDescription);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const addNewTeam = createAsyncThunk(
+  'project/addNewTeamStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+
+    try {
+      return await projectService.addNewTeam(project.addNewTeam);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const removeTeam = createAsyncThunk(
+  'project/removeTeamStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+
+    try {
+      return await projectService.removeTeam(project.removeTeam);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const archiveProject = createAsyncThunk(
+  'project/archiveProjectStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+    const { id } = project.overviewProject;
+
+    try {
+      return await projectService.archiveProject(id);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const unarchiveProject = createAsyncThunk(
+  'project/unarchiveProjectStatus',
+  async (_, thunkAPI) => {
+    const { project }: any = thunkAPI.getState();
+    const { id } = project.overviewProject;
+
+    try {
+      return await projectService.unarchiveProject(id);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+export const updateProjectStatus = createAsyncThunk(
+  'project/updateProjectStatus',
+  async (statusData: any, thunkAPI) => {
+    try {
+      return await projectService.updateProjectStatus(statusData);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+
+export const projectSlice = createSlice({
+  name: 'project',
+  initialState,
+  reducers: {
+    reset: (state) => {
+      state.isLoading = false
+      state.isError = false
+      state.isSuccess = false
+      state.newProject = {
+        title: "",
+        description: "",
+        teams: [
+          { name: "Frontend" },
+          { name: "Backend" }
+        ]
+      }
+      state.error = {
+        status: 0,
+        content: null
+      }
+    },
+    resetRefresher: (state) => {
+      state.refresher.teamStateUpdate = false;
+      state.refresher.memberStateUpdate = false;
+      state.refresher.projectStateUpdate = false;
+    },
+    startRefresher: (state) => {
+      state.refresher.teamStateUpdate = true;
+      state.refresher.memberStateUpdate = true;
+      state.refresher.projectStateUpdate = true;
+    },
+    teamRefresher: (state) => {
+      state.refresher.teamStateUpdate = true;
+    },
+    memberRefresher: (state) => {
+      state.refresher.memberStateUpdate = true;
+    },
+    projectRefresher: (state) => {
+      state.refresher.projectStateUpdate = true;
+    },
+
+    setProjectTeam: (state, { payload }) => {
+      state.newProject.teams = payload;
+    },
+    setProjectTitle: (state, { payload }) => {
+      state.newProject.title = payload;
+    },
+    setProjectDescription: (state, { payload }) => {
+      state.newProject.description = payload;
+    },
+
+    setTeamNewName: (state, { payload }) => {
+      state.renameTeamData.name = payload;
+    },
+    setID: (state, { payload: { teamID, projectID } }) => {
+      state.renameTeamData.teamID = teamID;
+      state.renameTeamData.projectID = projectID;
+    },
+
+    setAddTeam: (state, { payload }) => {
+      state.addNewTeam.teamData = payload;
+    },
+    setProjectId: (state, { payload }) => {
+      state.addNewTeam.projectID = payload;
+    },
+
+    setEditProjectID: (state, { payload }) => {
+      state.projectDescription.id = payload;
+    },
+    setEditProjectTitle: (state, { payload }) => {
+      state.projectDescription.title = payload;
+    },
+    setEditProjectDescription: (state, { payload }) => {
+      state.projectDescription.description = payload;
+    },
+
+    setRemoveTeamID: (state, { payload: { teamID, projectID } }) => {
+      state.removeTeam.teamID = teamID;
+      state.removeTeam.projectID = projectID;
+    },
+    setFilter: (state, { payload }) => {
+      state.filter = payload;
+    },
+  },
+  extraReducers: (builder: ActionReducerMapBuilder<any>) => {
+    builder
+      // Get Projects
+      .addCase(getSidebarProjects.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getSidebarProjects.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false;
+        state.sidebarProject = action.payload;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(getSidebarProjects.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+        state.user = null
+      })
+      // Get Filtered Projects
+      .addCase(filterProjects.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(filterProjects.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false;
+        state.project = action.payload;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(filterProjects.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+        state.user = null
+      })
+      // Get Project
+      .addCase(getProject.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(getProject.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false;
+        state.overviewProject = action.payload;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(getProject.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+        state.user = null
+      })
+      // Create Project
+      .addCase(createProject.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(createProject.fulfilled, (state) => {
+        state.isLoading = false;
+        state.newProject = {
+          title: "",
+          description: "",
+          teams: [
+            { name: "Frontend" },
+            { name: "Backend" }
+          ]
+        };
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(createProject.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Rename Team
+      .addCase(renameTeamData.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(renameTeamData.fulfilled, (state) => {
+        state.isLoading = false;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(renameTeamData.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Update Project Details
+      .addCase(updateProjectDetails.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(updateProjectDetails.fulfilled, (state) => {
+        state.isLoading = false;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(updateProjectDetails.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Add New Team
+      .addCase(addNewTeam.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(addNewTeam.fulfilled, (state) => {
+        state.isLoading = false;
+        state.addNewTeam = {
+          projectID: 0,
+          teamData: []
+        };
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(addNewTeam.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Remove Team
+      .addCase(removeTeam.pending, (state) => {
+        state.isLoading = true;
+      })
+      .addCase(removeTeam.fulfilled, (state) => {
+        state.isLoading = false;
+        state.removeTeam = {
+          projectID: 0,
+          teamID: 0
+        };
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(removeTeam.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Archive Project 
+      .addCase(archiveProject.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Unarchive Project 
+      .addCase(unarchiveProject.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+      // Update Project Status 
+      .addCase(updateProjectStatus.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true;
+        state.isSuccess = false;
+        state.isLoading = false;
+        state.error = action.payload;
+        state.user = null;
+      })
+  }
+})
+
+export const {
+  reset,
+  setID,
+  setFilter,
+  setAddTeam,
+  setProjectId,
+  teamRefresher,
+  resetRefresher,
+  startRefresher,
+  setTeamNewName,
+  setProjectTeam,
+  setRemoveTeamID,
+  setProjectTitle,
+  memberRefresher,
+  projectRefresher,
+  setEditProjectID,
+  setEditProjectTitle,
+  setProjectDescription,
+  setEditProjectDescription,
+} = projectSlice.actions
+export default projectSlice.reducer

--- a/client/src/redux/project/projectType.ts
+++ b/client/src/redux/project/projectType.ts
@@ -1,0 +1,2 @@
+export type ProjectType = {
+}

--- a/client/src/redux/setting/settingService.ts
+++ b/client/src/redux/setting/settingService.ts
@@ -1,0 +1,72 @@
+
+import { axios } from '~/shared/lib/axios'
+
+const updateProfileDetails = async (profileDetails: any): Promise<any> => {
+  const response = await axios.put('/api/user/change-details', profileDetails)
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return "Something went wrong";
+};
+const updatePassword = async (passwordDetails: any): Promise<any> => {
+  const response = await axios.put('/api/user/change-password', passwordDetails)
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return "Something went wrong";
+};
+const updateNotification = async (notificationDetails: any): Promise<any> => {
+  const { id, status } = notificationDetails
+
+  const response = await axios.put(`/api/user/setting/${id}`, { status })
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return "Something went wrong";
+};
+const uploadPhoto = async (photoData: any): Promise<any> => {
+  const formData = new FormData();
+  formData.append('avatar', photoData);
+  formData.append("_method", "POST");
+
+  const response = await axios.post('/api/user/setting', formData, {
+    headers: {
+      'Content-Type': 'multipart/form-data'
+    }
+  })
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return "Something went wrong";
+};
+const removePhoto = async (photoData: any): Promise<any> => {
+  const response = await axios.post('/api/user/setting', photoData, {
+    headers: {
+      'Content-Type': 'multipart/form-data'
+    }
+  })
+
+  if (response.status === 200) {
+    return response.data;
+  }
+
+  return "Something went wrong";
+};
+
+const authService = {
+  uploadPhoto,
+  removePhoto,
+  updatePassword,
+  updateNotification,
+  updateProfileDetails,
+}
+
+export default authService

--- a/client/src/redux/setting/settingSlice.ts
+++ b/client/src/redux/setting/settingSlice.ts
@@ -1,0 +1,184 @@
+import {
+  createSlice,
+  PayloadAction,
+  createAsyncThunk,
+  ActionReducerMapBuilder,
+} from '@reduxjs/toolkit'
+
+import { AxiosResponseError } from '~/shared/types'
+import { catchError } from '~/utils/handleAxiosError'
+import settingService from './settingService'
+
+type InitialState = {
+  isError: boolean
+  isSuccess: boolean
+  isLoading: boolean
+  error: AxiosResponseError
+}
+
+const initialState: InitialState = {
+  isError: false,
+  isSuccess: false,
+  isLoading: false,
+  error: {
+    status: 0,
+    content: null
+  }
+}
+
+export const updateProfileDetails: any = createAsyncThunk(
+  'auth/settingServiceStatus',
+  async (profileDetails: any, thunkAPI) => {
+    try {
+      return await settingService.updateProfileDetails(profileDetails)
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+export const updatePassword: any = createAsyncThunk(
+  'auth/updatePasswordStatus',
+  async (passwordDetails: any, thunkAPI) => {
+    try {
+      return await settingService.updatePassword(passwordDetails)
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+export const updateNotification: any = createAsyncThunk(
+  'auth/updateNotificationStatus',
+  async (notificationDetails: any, thunkAPI) => {
+    try {
+      return await settingService.updateNotification(notificationDetails)
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+export const uploadPhoto: any = createAsyncThunk(
+  'auth/uploadPhotoStatus',
+  async (photoData: any, thunkAPI) => {
+    try {
+      return await settingService.uploadPhoto(photoData)
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+export const removePhoto: any = createAsyncThunk(
+  'auth/removePhotoStatus',
+  async (_: any, thunkAPI) => {
+    try {
+      return await settingService.removePhoto("")
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
+export const settingSlice = createSlice({
+  name: 'setting',
+  initialState,
+  reducers: {
+    reset: (state) => {
+      state.isLoading = false
+      state.isError = false
+      state.isSuccess = false
+      state.error = {
+        status: 0,
+        content: null
+      }
+    },
+  },
+  extraReducers: (builder: ActionReducerMapBuilder<InitialState>) => {
+    builder
+      .addCase(updateProfileDetails.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(updateProfileDetails.fulfilled, (state) => {
+        state.isLoading = false
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(updateProfileDetails.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+
+      .addCase(updatePassword.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(updatePassword.fulfilled, (state) => {
+        state.isLoading = false
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(updatePassword.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+
+      .addCase(updateNotification.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(updateNotification.fulfilled, (state) => {
+        state.isLoading = false
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(updateNotification.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+
+      .addCase(uploadPhoto.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(uploadPhoto.fulfilled, (state) => {
+        state.isLoading = false
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(uploadPhoto.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+
+      .addCase(removePhoto.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(removePhoto.fulfilled, (state) => {
+        state.isLoading = false
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(removePhoto.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+      })
+  }
+})
+
+export const { reset } = settingSlice.actions
+export default settingSlice.reducer


### PR DESCRIPTION
## Issue Link
-  https://app.asana.com/0/1203011167276287/1203026696022136/f

## Definition of Done
- [x] User can see all the project list
- [x] User can filter projects based on the status

## Pre-condition
- yarn

## Expected Output
- When the user clicks the "All" option in the dropdown filter, all the projects should show.
- When the user clicks the "Archive" option in the dropdown menu, all the archived projects should show.
- When the user selects what status of project they want, it should be filtered and shown on the project list home page.

## Screenshots/Recordings
# Filter projects
![image](https://user-images.githubusercontent.com/104751512/194734579-12db6268-e429-42e2-975e-1390f8b2034f.png)
![image](https://user-images.githubusercontent.com/104751512/194734580-c19cf889-e8dd-403e-8b18-eb957f305f05.png)
![image](https://user-images.githubusercontent.com/104751512/194734582-3490beaf-a6e7-451d-863c-9cd82b3d96a7.png)

