### PR TITLE
[32] - [FE] Integrate Assign Team Lead Functionality

### DIFF
--- a/client/src/redux/member/memberService.ts
+++ b/client/src/redux/member/memberService.ts
@@ -71,13 +71,45 @@ const removeMember = async (removeMemberData: any): Promise<any> => {
   return "Something went wrong"
 }; 
 
+const leaveProject = async (projectID: any): Promise<any> => {  
+  const response = await axios.delete(`/api/project/${projectID}/leave`);
+
+  if (response.status === 200 || 204) {
+    return "Leave project successfully!";
+  }
+  return "Something went wrong"
+}; 
+
+const setAsTeamLead = async (teamLeadData: any): Promise<any> => {  
+  const {projectID, userID} = teamLeadData;
+  const response = await axios.post(`/api/project/${projectID}/team-lead`,{ user_id:userID });
+
+  if (response.status === 200 || 204) {
+    return "Successfully set as Team Lead!";
+  }
+  return "Something went wrong"
+}; 
+
+const setAsMVP = async (mvpData: any): Promise<any> => {  
+  const {projectID, userID} = mvpData;
+  const response = await axios.put(`/api/project/${projectID}/mvp`,{ user_id:userID });
+
+  if (response.status === 200 || 204) {
+    return "Successfully set as Team Lead!";
+  }
+  return "Something went wrong"
+}; 
+
 const memberService = {
+  setAsMVP,
   getMembers,
   getAllUsers,
   addNewMember,
   removeMember,
+  leaveProject,
   filterAllUser,
   filterMembers,
+  setAsTeamLead,
   editMemberTeam,
 };
 

--- a/client/src/redux/member/memberSlice.ts
+++ b/client/src/redux/member/memberSlice.ts
@@ -105,6 +105,42 @@ export const removeMember = createAsyncThunk(
   }
 );
 
+export const leaveProject = createAsyncThunk(
+  'project/leaveProjectStatus',
+  async (projectID: any, thunkAPI) => {
+
+    try {
+      return await memberService.leaveProject(projectID);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+
+export const setAsTeamLead = createAsyncThunk(
+  'project/setAsTeamLeadStatus',
+  async (teamLeadData: any, thunkAPI) => {
+
+    try {
+      return await memberService.setAsTeamLead(teamLeadData);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+
+export const setAsMVP = createAsyncThunk(
+  'project/setAsMVPStatus',
+  async (mvpData: any, thunkAPI) => {
+
+    try {
+      return await memberService.setAsMVP(mvpData);
+    } catch (error: any) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+);
+
 export const memberSlice = createSlice({
   name: 'member',
   initialState,
@@ -245,6 +281,60 @@ export const memberSlice = createSlice({
         }
       })
       .addCase(removeMember.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+        state.user = null
+      })
+      // Leave Project
+      .addCase(leaveProject.pending, (state) => { 
+        state.isLoading = true;
+      })
+      .addCase(leaveProject.fulfilled, (state) => {
+        state.isLoading = false;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(leaveProject.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+        state.user = null
+      })
+      // Set as Team Lead
+      .addCase(setAsTeamLead.pending, (state) => { 
+        state.isLoading = true;
+      })
+      .addCase(setAsTeamLead.fulfilled, (state) => {
+        state.isLoading = false;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(setAsTeamLead.rejected, (state, action: PayloadAction<any>) => {
+        state.isError = true
+        state.isSuccess = false
+        state.isLoading = false
+        state.error = action.payload
+        state.user = null
+      })
+      // Set as MVP
+      .addCase(setAsMVP.pending, (state) => { 
+        state.isLoading = true;
+      })
+      .addCase(setAsMVP.fulfilled, (state) => {
+        state.isLoading = false;
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(setAsMVP.rejected, (state, action: PayloadAction<any>) => {
         state.isError = true
         state.isSuccess = false
         state.isLoading = false


### PR DESCRIPTION
## Issue Link
-  https://app.asana.com/0/1203011167276287/1203026696022161/f

## Definition of Done
- [x] Project Owner and Team Lead can assign Team Lead.

## Pre-condition
- yarn

## Expected Output
- When P.O or T.L assigned a member as Team Lead, the member should have all the permissions as a team lead
- If a user is a team lead, the button will change from "Set as Team Lead" to "Remove as Team Lead"
- When a user is a Team Lead, they should have a fist badge

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/195965863-7e864881-4de9-4b29-a4c3-0dade68e4a47.png)
