### PR TITLE
[844] - [BugTask] Replace useEffect from Overview page to ProjectLayoutPage

### DIFF
--- a/client/src/components/molecules/MemberList/index.tsx
+++ b/client/src/components/molecules/MemberList/index.tsx
@@ -3,9 +3,17 @@ import { toast } from "react-hot-toast";
 import React, { useState } from "react";
 import ReactTooltip from "react-tooltip";
 
-import { MemberListProps } from './MemberListType';
+import { 
+  getAllUsers, 
+  removeMember, 
+  filterMembers, 
+  leaveProject, 
+  setAsTeamLead, 
+  setAsMVP, 
+} from "~/redux/member/memberSlice";
 import { FistIcon } from "~/shared/icons/FistIcon";
 import { StarIcon } from '~/shared/icons/StarIcon';
+import { MemberListProps } from './MemberListType';
 import { CrownIcon } from "~/shared/icons/CrownIcon";
 import { ThreeDot } from "~/shared/icons/ThreeDotIcon";
 import { ActiveStatus } from "~/shared/icons/ActiveStatus";
@@ -14,7 +22,6 @@ import LineSkeleton from "~/components/atoms/Skeletons/LineSkeleton";
 import ImageSkeleton from "~/components/atoms/Skeletons/ImageSkeleton";
 import { useAppDispatch, useAppSelector } from "~/hooks/reduxSelector";
 import { getProject, memberRefresher } from '~/redux/project/projectSlice';
-import { getAllUsers, removeMember, filterMembers, leaveProject, setAsTeamLead, setAsMVP } from "~/redux/member/memberSlice";
 
 const MemberList = ({
   data,

--- a/client/src/components/molecules/PeopeList/index.tsx
+++ b/client/src/components/molecules/PeopeList/index.tsx
@@ -1,15 +1,15 @@
 import React, { useState } from "react";
-
 import toast from "react-hot-toast";
+
 import { ThreeDot } from "~/shared/icons/ThreeDotIcon";
-import { addNewMember } from "~/redux/member/memberSlice";
 import { ActiveStatus } from "~/shared/icons/ActiveStatus";
 import PeopleOption from "~/components/organisms/PeopleOption";
-import { memberRefresher } from "~/redux/project/projectSlice";
 import AddPeopleButton from "~/components/atoms/AddPeopleButton";
 import LineSkeleton from "~/components/atoms/Skeletons/LineSkeleton";
+import { addNewMember, getAllUsers } from "~/redux/member/memberSlice";
 import ImageSkeleton from "~/components/atoms/Skeletons/ImageSkeleton";
 import { useAppDispatch, useAppSelector } from "~/hooks/reduxSelector";
+import { getProject, memberRefresher } from "~/redux/project/projectSlice";
 
 const PeopleList = ({ data, className, isLoading }: any) => {
   const dispatch = useAppDispatch();
@@ -22,15 +22,20 @@ const PeopleList = ({ data, className, isLoading }: any) => {
   const { overviewProject } = project || {};
   const { id: projectID, teams: projectTeams } = overviewProject || {};
 
+  const stateRefresh = () => {
+    dispatch(getProject(projectID));
+    dispatch(getAllUsers(projectID));
+  }
+
   const addPeople = () => {
+    setResetTeam(true);
     const newTeamData = { teams: selectedTeam, user_id: id, project_id: projectID };
 
-    setResetTeam(true);
-    setSelectedTeam([]);
     dispatch(memberRefresher());
     toast.promise(
       dispatch(addNewMember(newTeamData)).then((_) => {
         setResetTeam(false);
+        setSelectedTeam([]);
       }),
       {
         loading: 'Adding member...',
@@ -107,3 +112,7 @@ const PeopleList = ({ data, className, isLoading }: any) => {
 };
 
 export default PeopleList;
+function stateRefresh() {
+  throw new Error("Function not implemented.");
+}
+

--- a/client/src/components/organisms/AddMemberModal/index.tsx
+++ b/client/src/components/organisms/AddMemberModal/index.tsx
@@ -1,6 +1,12 @@
 import React, { useEffect, useState } from "react";
 import { ChevronDown, Search } from "react-feather";
 
+import {
+  getMembers,
+  getAllUsers,
+  filterAllUser,
+  filterMembers,
+} from "~/redux/member/memberSlice";
 import MemberFilter from "../MemberFilter";
 import DialogBox from "~/components/templates/DialogBox";
 import PeopleList from "~/components/molecules/PeopeList";
@@ -8,7 +14,6 @@ import MemberList from "~/components/molecules/MemberList";
 import { AddMemberFilterProps } from "./AddMemberFilterType";
 import AddPeopleButton from "~/components/atoms/AddPeopleButton";
 import { useAppDispatch, useAppSelector } from "~/hooks/reduxSelector";
-import { filterAllUser, filterMembers, getAllUsers, getMembers } from "~/redux/member/memberSlice";
 
 const AddMemberModal = ({ close }: AddMemberFilterProps) => {
   const dispatch = useAppDispatch();

--- a/client/src/pages/index.tsx
+++ b/client/src/pages/index.tsx
@@ -26,6 +26,7 @@ import { useAppSelector, useAppDispatch } from '~/hooks/reduxSelector'
 const Index: NextPage = (): JSX.Element => {
   const dispatch = useAppDispatch();
   const [limit, setLimit] = useState<boolean>(false);
+  const [isTitleDisabled, setIsTitleDisabled] = useState<boolean>(true);
   const [newProjectModal, setNewProjectModal] = useState<boolean>(false);
   const [preventStateReload, setPreventStateReload] = useState<boolean>(false);
 
@@ -44,13 +45,15 @@ const Index: NextPage = (): JSX.Element => {
 
   const onCreateProject = (): void => {
     setPreventStateReload(true);
+    setIsTitleDisabled(true);
     setNewProjectModal(false);
 
     toast.promise(
       dispatch(createProject(newProject))
         .then((_) => {
-          dispatch(filterProjects());
-          setPreventStateReload(false);
+          dispatch(filterProjects()).then((_) => {
+            setPreventStateReload(false);
+          });
         }),
       {
         loading: 'Creating new project...',
@@ -60,11 +63,10 @@ const Index: NextPage = (): JSX.Element => {
     )
   }
 
-  const [isTitleDisabled, setIsTitleDisabled] = useState<boolean>(true);
   const onChange = (e: any): void => {
     const value = e.target.value;
     const name = e.target.name;
-    const isDisable = value.length === 0;
+    const isDisable = value.length <= 0;
 
     if (name === "title") {
       dispatch(setProjectTitle(value));

--- a/client/src/pages/team/[id]/overview.tsx
+++ b/client/src/pages/team/[id]/overview.tsx
@@ -1,20 +1,17 @@
 import moment from 'moment'
 import { Plus } from 'react-feather'
 import { useRouter } from 'next/router'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useState } from 'react'
 
 import {
   setID,
   addNewTeam,
   getProject,
   teamRefresher,
-  startRefresher,
   setTeamNewName,
   resetRefresher,
   renameTeamData,
-  setEditProjectID,
   projectRefresher,
-  setUserPermission,
   setEditProjectTitle,
   updateProjectDetails,
   setEditProjectDescription,
@@ -31,7 +28,6 @@ import MembersTemplate from '~/components/molecules/MembersTemplate'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
 import { styles as homeStyle } from '~/shared/twin/home-content.style'
-import projectService from '~/redux/project/projectService'
 
 const Overview: FC = (): JSX.Element => {
   const router = useRouter();
@@ -44,9 +40,9 @@ const Overview: FC = (): JSX.Element => {
   const {
     isLoading,
     refresher,
-    userPermission: can,
     overviewProject,
     projectDescription,
+    userPermission: can,
     renameTeamData: getTeamData,
   } = useAppSelector((state) => state.project);
 
@@ -59,35 +55,8 @@ const Overview: FC = (): JSX.Element => {
     members,
     created_at,
     description,
-    can: userPermission,
     numberOfActiveMembers,
-    isLoading: reloadPermission,
   } = overviewProject || {};
-
-  useEffect(() => {
-    setTeamLimit(false);
-    dispatch(startRefresher());
-    dispatch(setEditProjectID(id));
-    dispatch(getProject(id)).then(_ => { dispatch(resetRefresher()) });
-  }, [id])
-
-  useEffect(() => {
-    dispatch(setEditProjectTitle(title));
-    dispatch(setEditProjectDescription(description));
-  }, [title, description])
-
-  useEffect(() => {
-    if (memberStateUpdate) {
-      dispatch(getProject(id))
-        .then(_ => {
-          dispatch(resetRefresher());
-        });
-    }
-  }, [memberStateUpdate])
-
-  useEffect(() => {
-    dispatch(setUserPermission(userPermission));
-  }, [reloadPermission, memberStateUpdate, id, title])
 
   const updateTitle = (e: any) => {
     const value = e.target.value;
@@ -300,7 +269,7 @@ const Overview: FC = (): JSX.Element => {
                       })
                 }
                 {
-                  memberStateUpdate || numberOfActiveMembers === 13 &&
+                  memberStateUpdate || numberOfActiveMembers >= 13 &&
                   <SeeMore set={setMembersLimit} what={membersLimit} />
                 }
               </div>

--- a/client/src/redux/project/projectSlice.ts
+++ b/client/src/redux/project/projectSlice.ts
@@ -319,7 +319,7 @@ export const projectSlice = createSlice({
     },
 
     setUserPermission: (state, { payload }) => {
-      state.userPermission = payload;
+      state.userPermission = payload; 
     }
   },
   extraReducers: (builder: ActionReducerMapBuilder<any>) => {
@@ -372,9 +372,10 @@ export const projectSlice = createSlice({
         state.isSidebarLoading = true;
       })
       .addCase(getProject.fulfilled, (state, action: PayloadAction<any>) => {
-        // state.isLoading = false;  
+        // state.isLoading = false;   
         state.isSidebarLoading = false;
         state.overviewProject = action.payload;
+        state.userPermission = action.payload.can;
         state.error = {
           status: 0,
           content: null


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203171599540843/f

## Definition of Done
- [x] User can add new members in the overview, board, and chat page

## Pre-condition
- `yarn`

## Expected Output
- Users should be able to add new members anywhere in the overview, board, and chat page even if they reload the page.

## Screenshots/Recordings
https://user-images.githubusercontent.com/104751512/196093703-72ac9dae-2e7a-42f1-ab6e-e99557653058.mp4

