### PR TITLE
[855] - [Markup] Set project description in overview page to be un-resizable

### DIFF
--- a/client/src/pages/team/[id]/overview.tsx
+++ b/client/src/pages/team/[id]/overview.tsx
@@ -221,7 +221,7 @@ const Overview: FC = (): JSX.Element => {
                     if (editDescription?.length === 0) return dispatch(setEditProjectDescription(description));
                     if (editDescription !== description) return onSaveChanges();
                   }}
-                  className='text-sm text-slate-500 break-words border border-slate-300 p-5 rounded-md'
+                  className='text-sm text-slate-500 break-words border border-slate-300 p-5 rounded-md resize-none'
                 />
               }
 


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203170770944855/f

## Definition of Done
- [x] User cannot resize project description board. 

## Pre-condition
- na

## Expected Output
- The user shouldn't be able to resize the project description on the overview page.

## Screenshots/Recordings
![image](https://user-images.githubusercontent.com/104751512/196134091-67e27a7d-bb1f-4aca-9a04-f1cc5e7bc091.png)
