### PR TITLE
[076] - [BugTask] Section Title dispatches update even no changes were made

### DIFF
--- a/client/src/components/organisms/BoardSection/index.tsx
+++ b/client/src/components/organisms/BoardSection/index.tsx
@@ -40,6 +40,7 @@ const BoardSection: FC<Props> = (props): JSX.Element => {
   const handleUpdateSection = (e: any, id: number) => {
     if (e.key === 'Enter' || e.keyCode === 13) {
       isBlur = false
+      if (e.target.value === name) return
       updateSection(e, id)
       e.target.blur()
     }
@@ -50,6 +51,7 @@ const BoardSection: FC<Props> = (props): JSX.Element => {
       if (e.target.value.length === 0) {
         e.target.value = 'Untitled Section'
       }
+      if (e.target.value === name) return
       updateSection(e, id)
     }
   }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203173674936076/f

## Definition of Done
- [x] Added a condition where the new title is not equal to the old title

## Pre-condition
- n/a

## Expected Output
- Section title should not change and dispatch when you press enter or blur out from the input, rather it only dispatches when a changes is made to the input

## Screenshots/Recordings


https://user-images.githubusercontent.com/110364637/196402161-268e941c-19d9-4939-b0ba-49d03d1165db.mp4

