### PR TITLE
[753] - [BugTask] The archive dropdown does not extend beyond the sidebar

### DIFF
--- a/client/src/shared/twin/project-action-dropdown.styles.ts
+++ b/client/src/shared/twin/project-action-dropdown.styles.ts
@@ -20,7 +20,7 @@ export const styles = {
   ],
   menu_items: [
     tw`
-      absolute right-0 w-44 origin-top-right divide-y
+      absolute left-0 w-44 origin-top-left divide-y
       divide-gray-200 overflow-hidden rounded-md bg-white shadow-xl
        focus:outline-none border border-[${slate_200}]
     `


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203188305344023/f

## Definition of Done
- [x] Changed the behavioral dropdown origin-top-right style into top-left display

## Pre-condition
- n/a

## Expected Output
- You should able to see the dropdown top-right into top-left display

## Screenshots/Recordings

![top-right](https://user-images.githubusercontent.com/108642414/196344206-038c52f3-ea17-46ca-ab3a-f1e120f2557f.gif)

