### PR TITLE
[735] - [BugTask] Edit task name in the task box when the user clicks outside it should disable the input.

### DIFF
--- a/client/src/components/molecules/TaskList/index.tsx
+++ b/client/src/components/molecules/TaskList/index.tsx
@@ -136,7 +136,7 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
       if (e.target.value.length === 0) {
         return (e.target.value = task?.name)
       }
-      if (e.target.value === task?.name) return
+      if (e.target.value === task?.name) return (inputElement.current.disabled = true)
       useHandleUpdateTaskName(task?.section_id as number, task?.id as number, e.target.value)
       inputElement.current.disabled = true
     }
@@ -147,7 +147,7 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
 
     if (keyCode === 13) {
       e.preventDefault()
-      if (e.target.value === task?.name) return
+      if (e.target.value === task?.name) return (inputElement.current.disabled = true)
       useHandleUpdateTaskName(task?.section_id as number, task?.id as number, e.target.value)
       isBlur = false
       inputElement.current.disabled = true


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203196285278735/f

## Definition of Done
- [x] Input is disabled when pressing enter or clicking outside when there is no changes

## Pre-condition
- n/a

## Expected Output
- Task title should be disabled if no changes made when pressing enter or clicking outside it 

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/196610877-a2dd803c-2710-4624-ab4c-91c4f98f1a4a.mp4



