### PR TITLE
[729] - [BugTask] Fix the default images in the board details

### DIFF
--- a/client/src/components/organisms/TaskSlider/index.tsx
+++ b/client/src/components/organisms/TaskSlider/index.tsx
@@ -419,6 +419,7 @@ const TaskSlider: FC<Props> = (props): JSX.Element => {
                         <img
                           className="h-8 w-8 rounded-lg"
                           src={updateAssignee?.user?.avatar?.url}
+                          onError={(e) => handleImageError(e, '/images/avatar.png')}
                         />
                       </button>
                     ) : (


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203196285278729/f

## Definition of Done
- [x] Fixed the default avatar image in task slider not displaying when link is broken

## Notes
- None

## Pre-condition
- Go to dev server and click on a task

## Expected Output
- User will be able to a see a default avatar image whenever the url provided is broken

## Sreenshots/Recordings
- Default Avatar Image

![default-image-fix](https://user-images.githubusercontent.com/108660012/196609744-61265b2d-d11a-4b89-b586-3c15db3a63e8.png)
