### PR TITLE
[755] - [BugTask] - Options Button in task component is hidden while renaming

### DIFF
--- a/client/src/components/molecules/TaskList/index.tsx
+++ b/client/src/components/molecules/TaskList/index.tsx
@@ -131,8 +131,10 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
   }
 
   let isBlur = true
+  const [isEditing, setIsEditing] = useState(false)
   const onBlurUpdateTaskName = (e: any) => {
     if (isBlur) {
+      setIsEditing(false)
       if (e.target.value.length === 0) {
         return (e.target.value = task?.name)
       }
@@ -147,6 +149,7 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
 
     if (keyCode === 13) {
       e.preventDefault()
+      setIsEditing(false)
       if (e.target.value === task?.name) return (inputElement.current.disabled = true)
       useHandleUpdateTaskName(task?.section_id as number, task?.id as number, e.target.value)
       isBlur = false
@@ -155,6 +158,7 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
   }
 
   const onClickRenameTask = (): void => {
+    setIsEditing(true)
     inputElement.current.disabled = false
     inputElement.current.select()
     inputElement.current.focus()
@@ -261,7 +265,7 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
           ref={inputElement}
         />
         <div className="absolute right-2 top-2 opacity-0 group-task-hover:opacity-100 group-task-focus:opacity-100">
-          {(permissions?.deleteTask || permissions?.renameTask) && (
+          {(permissions?.deleteTask || permissions?.renameTask) && !isEditing && (
             <Menu as="div" className="relative z-10 inline-block items-center bg-white text-left">
               {({ open }) => (
                 <>

--- a/client/src/components/organisms/TaskSlider/index.tsx
+++ b/client/src/components/organisms/TaskSlider/index.tsx
@@ -46,7 +46,7 @@ const TaskSlider: FC<Props> = (props): JSX.Element => {
   const {
     useHandleUpdateTaskDueDate,
     useHandleUpdateTaskAssignee,
-    useHandleCompleteTask,
+    useHandleCompleteTaskSlider,
     useHandleRefetchTasks,
     useHandleUpdateTaskName,
     useHandleUpdateTaskDetails,
@@ -82,7 +82,7 @@ const TaskSlider: FC<Props> = (props): JSX.Element => {
 
   const handleTaskStatusToggle = async () => {
     setIsTaskCompleted(!isTaskCompleted)
-    useHandleCompleteTask(parseInt(task_id as string))
+    useHandleCompleteTaskSlider(parseInt(task_id as string))
   }
 
   const handleUpdateAssigneeToggle = () => {

--- a/client/src/hooks/taskMethods.ts
+++ b/client/src/hooks/taskMethods.ts
@@ -49,9 +49,11 @@ export const useTaskMethods = (projectID: number) => {
     dispatch(setAddNewTaskData(data))
     toast.promise(
       dispatch(createTask()).then((_) => {
-        dispatch(getSections()).then((_) => {
-          dispatch(resetRefresher())
-          callback()
+        dispatch(reorderTasks()).then((_) => {
+          dispatch(getSections()).then((_) => {
+            dispatch(resetRefresher())
+            callback()
+          })
         })
       }),
       {
@@ -60,7 +62,6 @@ export const useTaskMethods = (projectID: number) => {
         error: 'Error on creating task!'
       }
     )
-    useHandleReorderTasks(section_id)
   }
 
   const useHandleRemoveTask = async (section_id: number, task_id: number) => {
@@ -68,7 +69,9 @@ export const useTaskMethods = (projectID: number) => {
     dispatch(setRemoveTaskData({ id: task_id }))
     toast.promise(
       dispatch(removeTask()).then((_) => {
-        dispatch(getSections())
+        dispatch(reorderTasks()).then((_) => {
+          dispatch(getSections())
+        })
       }),
       {
         loading: 'Removing task...',
@@ -76,7 +79,6 @@ export const useTaskMethods = (projectID: number) => {
         error: 'Error on removing task!'
       }
     )
-    useHandleReorderTasks(section_id)
   }
   const useHandleReorderTasks = async (section_id: number) => {
     dispatch(setSectionID({ section_id }))
@@ -124,6 +126,10 @@ export const useTaskMethods = (projectID: number) => {
   }
   const useHandleCompleteTask = async (id: number) => {
     dispatch(setCompleteTaskData({ id }))
+    dispatch(completeTask())
+  }
+  const useHandleCompleteTaskSlider = async (id: number) => {
+    dispatch(setCompleteTaskData({ id }))
     dispatch(completeTask()).then((_) => dispatch(getSections()))
   }
   const useHandleGetTask = async (task_id: number) => {
@@ -161,6 +167,7 @@ export const useTaskMethods = (projectID: number) => {
     useHandleUpdateTaskDetails,
     useHandleRefetchTasks,
     useHandleGetTaskWithoutLoading,
+    useHandleCompleteTaskSlider,
     taskUpdate,
     isTaskLoading,
     taskData


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203196285278755/f

## Definition of Done
- [x] Fixed the option button to hide when the user is editing task name

## Notes
- None

## Pre-condition
- Go to dev server, choose a task and try to edit a task name on the task box

## Expected Output
- User should be hidden when the user is currently editing the task name or renaming it

## Sreenshots/Recordings


https://user-images.githubusercontent.com/110364637/196646125-402e84ba-7c86-45dc-b3ef-114dd38436d9.mp4


