### PR TITLE
[024] - [BugTask] Ellipses is not displayed in the Assignee field if the name is too long.

### DIFF
--- a/client/src/components/organisms/TaskSlider/index.tsx
+++ b/client/src/components/organisms/TaskSlider/index.tsx
@@ -435,9 +435,13 @@ const TaskSlider: FC<Props> = (props): JSX.Element => {
                   {updateAssignee?.user && (
                     <div className="flex flex-col text-sm">
                       <div className="flex items-center space-x-3">
-                        <h1 className="font-medium">{updateAssignee?.user?.name}</h1>
-                        <span className="h-2 w-2 rounded-full bg-green-600"></span>
-                        <p className="text-slate-500">{updateAssignee?.role?.name}</p>
+                        <Tooltip text={updateAssignee?.user?.name}>
+                          <h1 className="max-w-[120px] font-medium line-clamp-1">
+                            {updateAssignee?.user?.name}
+                          </h1>
+                        </Tooltip>
+                        <span className="h-2 w-2 flex-shrink-0 rounded-full bg-green-600"></span>
+                        <p className="text-slate-500 line-clamp-1">{updateAssignee?.role?.name}</p>
                       </div>
                       <h2 className="leading-tight text-slate-500">
                         {updateAssignee?.teams


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203204418582024/f

## Definition of Done
- [x] Truncate the long name and show tooltip for actual displayed name

## Notes
- None

## Pre-condition
`yarn dev`

## Expected Output
- User name should truncate when its too long and show the tooltip for the actual name

## Sreenshots/Recordings
![line-clmap](https://user-images.githubusercontent.com/108642414/196850424-6d9ccad0-ceb6-4937-8ef4-811395133ab8.gif)

