### PR TITLE
[030] - [Markup] Display Hide/Show password icon in the Sign In and Sign Up password Field.

### DIFF
--- a/client/src/components/molecules/AuthForm/index.tsx
+++ b/client/src/components/molecules/AuthForm/index.tsx
@@ -1,13 +1,14 @@
-import React, { FC } from 'react'
 import { useForm } from 'react-hook-form'
+import React, { FC, useState } from 'react'
+import { EyeOff, Eye } from 'react-feather'
 import { yupResolver } from '@hookform/resolvers/yup'
 
+import { useAuthStatus } from '~/hooks/authStatus'
 import { styles } from '~/shared/twin/auth.styles'
 import { SignInUpFormValues } from '~/shared/types'
 import { Spinner } from '~/shared/icons/SpinnerIcon'
 import { globals } from '~/shared/twin/globals.styles'
 import { SignInFormSchema, SignUpFormSchema } from '~/shared/validation'
-import { useAuthStatus } from '~/hooks/authStatus'
 
 type Props = {
   isLogin: boolean
@@ -17,22 +18,25 @@ type Props = {
 }
 
 const AuthForm: FC<Props> = (props): JSX.Element => {
+  const [showPass, setShowPass] = useState(false)
   const {
     isLogin,
     actions: { handleAuthSubmit }
   } = props
-  
+
   const {
     register,
     handleSubmit,
     setError,
-    formState: { errors } 
+    formState: { errors }
   } = useForm<SignInUpFormValues>({
     mode: 'onTouched',
     resolver: yupResolver(isLogin ? SignInFormSchema : SignUpFormSchema)
   })
 
   const { isLoading } = useAuthStatus(setError)
+
+  const handleShowPasswordToggle = (): void => setShowPass(!showPass)
 
   return (
     <form css={styles.form} onSubmit={handleSubmit(handleAuthSubmit)}>
@@ -68,13 +72,41 @@ const AuthForm: FC<Props> = (props): JSX.Element => {
         <label htmlFor="password" css={globals.form_label}>
           Password <span>*</span>
         </label>
-        <input
-          type="password"
-          css={globals.form_control}
-          disabled={isLoading}
-          placeholder="•••••••••"
-          {...register('password')}
-        />
+        <div className="relative flex items-center">
+          <input
+            type={showPass ? 'text' : 'password'}
+            css={globals.form_control}
+            disabled={isLoading}
+            placeholder="•••••••••"
+            {...register('password')}
+            className="!pr-10"
+          />
+          <button
+            type="button"
+            className={`
+               group absolute inset-y-0 right-0 block overflow-hidden rounded-r 
+               px-2.5 outline-none transition duration-75 ease-in-out
+               focus:bg-slate-100 hover:bg-slate-100
+            `}
+            onClick={handleShowPasswordToggle}
+          >
+            {showPass ? (
+              <Eye
+                className={`
+                h-4 w-4 text-slate-500 group-hover:text-slate-800 
+                group-focus:text-slate-800
+            `}
+              />
+            ) : (
+              <EyeOff
+                className={`
+                h-4 w-4 text-slate-500 group-hover:text-slate-800 
+                group-focus:text-slate-800
+            `}
+              />
+            )}
+          </button>
+        </div>
         {errors?.password && <span className="error">{`${errors?.password?.message}`}</span>}
       </div>
       {!isLogin && (

--- a/client/src/components/templates/AuthLayout/index.tsx
+++ b/client/src/components/templates/AuthLayout/index.tsx
@@ -31,13 +31,6 @@ const AuthLayout: FC<Props> = ({ children, metaTitle }): JSX.Element => {
             </div>
             <div css={styles.google_provider}>
               <h1>{isSignUp ? 'Sign Up' : 'Sign In'} to Slackana</h1>
-              <button type="button" className="focus:outline-blue-600">
-                <GoogleIcon />
-                <span>Continue with Google</span>
-              </button>
-              <div css={styles.or}>
-                <span>or</span>
-              </div>
             </div>
           </nav>
           {children}


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203204418582030/f

## Definition of Done
- [x] The password field can now have show and hide eye icon toggle
- [x] I also remove the login with google button

## Notes
- None

## Pre-condition
go to auth page

## Expected Output
- User will be able to toggle hide and show password in login/register field
- You no longer see the login with google button

## Sreenshots/Recordings
![toggle hide show](https://user-images.githubusercontent.com/108642414/196866848-6eb82f1b-ac9d-46b7-b5e5-961e75a0d1d4.gif)

### UPDATED
![updated-toggle](https://user-images.githubusercontent.com/108642414/196881032-bd107685-1a9d-4b5a-a6aa-73de7dacaf46.gif)
