### PR TITLE
[680] - [FE] Add Protected Routes when a user is not a member of the Project

### DIFF
--- a/api/app/Http/Controllers/ProjectMemberController.php
+++ b/api/app/Http/Controllers/ProjectMemberController.php
@@ -19,10 +19,16 @@ class ProjectMemberController extends Controller
     }
     if(request('search')){
       return MemberResource::collection($project->members()->whereHas('user', function($query){
-        $query->where('name', 'like', '%' . request('search') . '%');
+        $query->where('name', 'ilike', '%' . request('search') . '%');
       } )->with(['user.avatar','role', 'teams'])->get());
     }
     return MemberResource::collection($project->members()->with(['role', 'user.avatar', 'teams'])->get());
+  }
+
+  public function show(Project $project, User $member)
+  {
+    $project->members()->where('user_id', $member->id)->firstOrFail();
+    return response()->noContent();
   }
 
   public function store(StoreProjectMemberRequest $request, Project $project)

--- a/client/src/components/molecules/MemberList/index.tsx
+++ b/client/src/components/molecules/MemberList/index.tsx
@@ -23,6 +23,7 @@ import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import ImageSkeleton from '~/components/atoms/Skeletons/ImageSkeleton'
 import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
 import { getProject, memberRefresher } from '~/redux/project/projectSlice'
+import { useRouter } from 'next/router'
 
 const MemberList = ({
   data,
@@ -49,7 +50,8 @@ const MemberList = ({
       return team?.name
     })
     .join(' | ')
-
+  
+  const router = useRouter()
   const [isClicked, setIsClicked] = useState<boolean>(false)
 
   const handleBellClick = (currentUserID: number, isLoggedIn: boolean) => {
@@ -103,7 +105,7 @@ const MemberList = ({
       case 3: {
         return toast.promise(
           dispatch(leaveProject(projectID)).then((_) => {
-            stateRefresh()
+            router.push('/')
           }),
           {
             loading: 'Leaving project...',

--- a/client/src/utils/getServerSideProps.ts
+++ b/client/src/utils/getServerSideProps.ts
@@ -32,14 +32,26 @@ export const signInUpAuthCheck: GetServerSideProps = wrapper.getServerSideProps(
 
 export const authCheck: GetServerSideProps = wrapper.getServerSideProps(
   (store) =>
-    async ({ req }) => {
+    async ({ req, params }) => {
       const token = req.cookies['token']
       const config = { headers: { Authorization: `Bearer ${token}` } }
 
       try {
         const res = await axios.get('/api/auth', config)
         store.dispatch(setAuth(res.data))
+        if (
+          req.url?.includes('overview') ||
+          req.url?.includes('chat') ||
+          req.url?.includes('board')
+        ) {
+          await axios.get(`/api/project/${params?.id}/member/${res.data.id}`, config)
+        }
       } catch (error: any) {
+        if (error.response.status === 404) {
+          return {
+            notFound: true
+          }
+        }
         return {
           redirect: {
             permanent: false,


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203188269473680/f

## Definition of Done
- [x] Added extra protection to the routes whenever a user visits a project
- [x] Created a server side check whenever there are changes in the project id url

## Notes
- When a project is not found you will be redirected to the 404 page

## Pre-condition
- A user accesses a project in which that user does not belong to it
- A user accesses a not existed project 

## Expected Output
- The user will be redirected to the 404 page

## Screenshots/Recordings
[screen-recording (4).webm](https://user-images.githubusercontent.com/108660012/197356302-5518b5d0-3dc5-40de-8d5c-1fdd45d3b15a.webm)
