### PR TITLE
[088] - [FE] Allow Own Task to be moved Function

### DIFF
--- a/client/src/pages/team/[id]/board.tsx
+++ b/client/src/pages/team/[id]/board.tsx
@@ -30,6 +30,7 @@ import AddTask from '~/components/molecules/AddTask'
 import TaskList from '~/components/molecules/TaskList'
 import TaskSlider from '~/components/organisms/TaskSlider'
 import { useTaskMethods } from '~/hooks/taskMethods'
+import { useProjectMethods } from '~/hooks/projectMethods'
 
 const Board: NextPage = (): JSX.Element => {
   const router = useRouter()
@@ -41,6 +42,7 @@ const Board: NextPage = (): JSX.Element => {
     useHandleUpdateTaskSection,
     useHandleUpdateTaskPosition
   } = useTaskMethods(parseInt(id as string))
+  const { permissions, canComplete: canMove } = useProjectMethods(parseInt(id as string))
   const dispatch = useAppDispatch()
   const [newTaskDueDate, setNewTaskDueDate] = useState('')
   const [currentBoardId, setCurrentBoardId] = useState<any>(null)
@@ -289,6 +291,7 @@ const Board: NextPage = (): JSX.Element => {
       useHandleSetSections(temp)
       useHandleUpdateTaskSection(destination.droppableId, draggableId)
       useHandleUpdateTaskPosition(result[destination.droppableId])
+      useHandleUpdateTaskPosition(result[source.droppableId])
     }
   }
   return (
@@ -328,8 +331,14 @@ const Board: NextPage = (): JSX.Element => {
                         )}
                         {board.tasks?.length ? (
                           board.tasks.map((task: any, i: number) => {
+                            let moveTask = !permissions?.moveTask || !canMove(task?.assignee?.id)
                             return (
-                              <Draggable key={task.id} draggableId={task.id + ''} index={i}>
+                              <Draggable
+                                isDragDisabled={moveTask}
+                                key={task.id}
+                                draggableId={task.id + ''}
+                                index={i}
+                              >
                                 {(provided, snapshot) => (
                                   <TaskList
                                     task={task}


### PR DESCRIPTION
## Asana Link
- https://app.asana.com/0/1203011167276287/1203128830923088/f

## Definition of Done
- [x] Added permissions for moving tasks
- [x] PO / TL can move any tasks assigned to anyone
- [x] Member can move only the tasks assigned to him/her and cannot move other task


## Notes
- None

## Pre-condition
- Login as PO/TL/Member
- Go to a particular project
- Go to the boards
- Move any tasks across any sections

## Expected Output
- Should be able to move any tasks if the logged in user is a PO/TL but cannot move any task other than the one assigned to him/her if the logged user is Member

## Screenshots/Recordings
- PO/TL moving any task (John Doe)

https://user-images.githubusercontent.com/110364637/197914952-6b2d2951-ca81-4a27-aa51-d3d3b4273025.mp4


- Member moving his task and cannot move anyone else's (Jane Doe)

https://user-images.githubusercontent.com/110364637/197915448-f459b1e3-7e88-42ad-9683-405640861123.mp4



