### PR TITLE
[437] - [BE] Implement, Fetch, Mark as Read, and Filter Notifications functionality according to a selected project

### DIFF
--- a/api/app/Http/Controllers/NotificationController.php
+++ b/api/app/Http/Controllers/NotificationController.php
@@ -9,7 +9,18 @@ class NotificationController extends Controller
 {
   public function index(Request $request)
   {
-    return auth()->user()->notifications;
+    $notifications = auth()->user()->notifications;
+    if (request('type') === 'unread') {
+      $notifications = $notifications->filter(function ($notification) {
+        return $notification->read_at === null;
+      })->values();
+    }
+    if (request('project')) {
+      $notifications = $notifications->filter(function ($notification) {
+        return intval($notification->data['project_id']) === intval(request('project'));
+      })->values();
+    }
+    return $notifications;
   }
 
   public function update(DatabaseNotification $notification, Request $request)

--- a/api/app/Http/Controllers/UserController.php
+++ b/api/app/Http/Controllers/UserController.php
@@ -18,7 +18,7 @@ class UserController extends Controller
     };
 
     if (request('search')) {
-      return UserResource::collection(User::with(['avatar'])->where('name', 'like', '%' . request('search') . '%')->whereNotIn('id', $memberIds)->get());
+      return UserResource::collection(User::with(['avatar'])->where('name', 'ilike', '%' . request('search') . '%')->whereNotIn('id', $memberIds)->get());
     }
 
     return UserResource::collection(User::with(['avatar'])->whereNotIn('id', $memberIds)->get());


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203247946500437/f

## Definition of Done
- [x] Users can already Fetch, Mark as Read, and Filter Notifications functionality according to a selected project

## Notes
- I only added here the filtering functionality specific to a selected project as I have implement both fetching of all tasks and marking it as read in the previous PR here: https://github.com/abduljalilpalala/ps-slackana/pull/137

## Pre-condition
- Open postman
- send a GET request to http://localhost:8000/api/notification?project=1&type=all to get notifications and filter it)
- send a PUT request to http://localhost:8000/api/notification/1 to mark notification as read

## Expected Output
- Users can Fetch, Mark as Read, and Filter Notifications functionality according to a selected project

## Screenshots/Recordings
- Get all notifications with filtering
![image](https://user-images.githubusercontent.com/110364637/198546764-0b1b91a1-42d6-4892-b857-3238da0bbe06.png)


