### PR TITLE
[493] - [FE] Do automatic input search on the add member search field.

### DIFF
--- a/client/src/components/organisms/AddMemberModal/index.tsx
+++ b/client/src/components/organisms/AddMemberModal/index.tsx
@@ -1,12 +1,8 @@
 import React, { useEffect, useState } from 'react'
 import { ChevronDown, Search } from 'react-feather'
 
-import {
-  getMembers,
-  getAllUsers,
-  filterMembers,
-  filterAllUser,
-} from '~/redux/member/memberSlice'
+import { getMembers, getAllUsers, filterMembers, filterAllUser } from '~/redux/member/memberSlice'
+import { useDebounceSearch } from '~/hooks/debounceSearch'
 import MemberFilter from '../MemberFilter'
 import { useNudgeMember } from '~/hooks/nudge'
 import DialogBox from '~/components/templates/DialogBox'
@@ -35,31 +31,18 @@ const AddMemberModal = ({ close }: AddMemberFilterProps) => {
   const { id: projectID, teams } = overviewProject || {}
   const { id: teamID, name } = filterData
 
+  const debouncedSearch = useDebounceSearch(search, 500)
+
   const setFilter = (data: any): void => {
     setFilterData(data)
   }
 
-  const onSearchChange = (e: any): void => {
-    const value = e.target.value
-    setSearch(value)
-    if (value.length === 0) {
-      setIsLoading(true)
-      dispatch(filterAllUser({ projectID, searchValue: value })).then((_) => {
-        setIsLoading(false)
-      })
-    }
-  }
-
-  const onSearch = (e: any): void => {
-    const value = e.target.value
-    const isEnter = e.key === 'Enter' || e.keyCode === 13
-
-    if (!isEnter) return
+  useEffect(() => {
     setIsLoading(true)
-    dispatch(filterAllUser({ projectID, searchValue: value })).then((_) => {
+    dispatch(filterAllUser({ projectID, searchValue: debouncedSearch })).then((_) => {
       setIsLoading(false)
     })
-  }
+  }, [debouncedSearch])
 
   useEffect(() => {
     dispatch(getMembers(projectID))
@@ -101,8 +84,7 @@ const AddMemberModal = ({ close }: AddMemberFilterProps) => {
             <input
               type="text"
               value={search || ''}
-              onKeyDown={onSearch}
-              onChange={onSearchChange}
+              onChange={(e) => setSearch(e.target.value)}
               className="mr-5 w-full border-none text-slate-900 focus:ring-transparent"
               placeholder="Find members"
             />

--- a/client/src/hooks/debounceSearch.ts
+++ b/client/src/hooks/debounceSearch.ts
@@ -1,0 +1,17 @@
+import { useEffect, useState } from 'react'
+
+export const useDebounceSearch = (value: string, delay: number) => {
+  const [debouncedValue, setDebouncedValue] = useState<string>(value)
+
+  useEffect(() => {
+    const handler = setTimeout(() => {
+      setDebouncedValue(value)
+    }, delay)
+
+    return () => {
+      clearTimeout(handler)
+    }
+  }, [value, delay])
+
+  return debouncedValue
+}


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276215/1203219881282493/f

## Definition of Done
- [x] Implemented search functionality in which whenever the user types in the search bar, it automatically searches the database and returns the result based on the words that were typed

## Notes
- Use Debounce method to reduce the number of requests to be made when the user types in the search bar

## Pre-condition
1. Go to the members modal and add people
2. Search for the user that you want to add

## Expected output
- Whenever the user types it displays its corresponding result

## Screenshots/Recordings
[screen-recording (7).webm](https://user-images.githubusercontent.com/108660012/198561661-a3f970fe-e767-4752-aeb7-affff5e0ab98.webm)
