### PR TITLE
[436] - [Markup] Create Notifications Page

### DIFF
--- a/client/src/components/molecules/FileList/FIleItem.tsx
+++ b/client/src/components/molecules/FileList/FIleItem.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from 'react'
-import ReactTooltip from 'react-tooltip'
+import dynamic from 'next/dynamic'
 import { Edit3, Trash, Download } from 'react-feather'
 
 import { Filename } from '~/shared/types'
 import { File } from '~/shared/interfaces'
 import { fileIconType } from '~/shared/jsons/fileIconType'
+
+const ReactTooltip = dynamic(() => import('react-tooltip'), { ssr: false })
 
 type Props = {
   file: File

--- a/client/src/components/molecules/NotificationList/index.tsx
+++ b/client/src/components/molecules/NotificationList/index.tsx
@@ -1,0 +1,80 @@
+import moment from 'moment'
+import React, { FC } from 'react'
+import { GitHub } from 'react-feather'
+import { BsGithub } from 'react-icons/bs'
+import { FaRegUser } from 'react-icons/fa'
+
+import { Notification } from '~/shared/interfaces'
+
+type Props = {
+  notifications: Notification[]
+}
+
+const NotificationList: FC<Props> = (props): JSX.Element => {
+  if (!props.notifications) null
+
+  const notificationIconType = [
+    {
+      name: 'committed',
+      Icon: GitHub
+    },
+    {
+      name: 'merged',
+      Icon: BsGithub
+    },
+    {
+      name: 'assigned',
+      Icon: FaRegUser
+    }
+  ]
+
+  const showNotificationTypeText = (text: string) => {
+    switch (text) {
+      case 'assigned':
+        return (text = 'has assigned you a task -')
+      case 'merged':
+        return (text = 'has merged this pull request -')
+      case 'committed':
+        return (text = 'has committed to project')
+    }
+  }
+
+  return (
+    <table className="min-w-2xl w-full flex-1 divide-y divide-slate-300 overflow-auto border-t border-slate-300 text-left text-sm leading-normal">
+      <tbody className="w-full divide-y divide-slate-300 text-sm text-slate-600">
+        {props.notifications?.map((notification, i) => (
+          <tr
+            key={i}
+            className="group flex-1 shrink-0 text-sm transition duration-75 ease-in-out hover:bg-slate-100"
+          >
+            <td className="flex flex-1 items-center px-6 md:justify-between">
+              <div className="flex flex-wrap items-center space-x-2 py-2 text-slate-600">
+                {notificationIconType.map(
+                  (notifIcon, i) =>
+                    notifIcon.name.includes(notification.notification_type) && (
+                      <notifIcon.Icon key={i} className="h-4 w-4 shrink-0" />
+                    )
+                )}
+                <div className="shrink-0 font-semibold text-slate-900">{notification?.name}</div>
+                <span className="flex-shrink-0 font-normal">
+                  {showNotificationTypeText(notification.notification_type)}
+                </span>
+                <a
+                  href={notification.link}
+                  className="font-semibold text-slate-900 underline line-clamp-1"
+                >
+                  {notification.task_name}
+                </a>
+              </div>
+              <span className="shrink-0 text-sm font-light text-slate-500">
+                {moment(notification.created_at).fromNow()}
+              </span>
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default NotificationList

--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -1,4 +1,5 @@
 import React, { FC } from 'react'
+import { useRouter } from 'next/router'
 import { IoIosMenu } from 'react-icons/io'
 
 import Logo2Icon from '~/shared/icons/Logo2Icon'
@@ -14,28 +15,43 @@ type Props = {
 }
 
 const Header: FC<Props> = (props): JSX.Element => {
+  const router = useRouter()
   const { handleToggleSidebar, handleToggleDrawer } = props.actions
 
   return (
     <header css={styles.header}>
       <div css={styles.container}>
         <div css={styles.menu_wrapper}>
-          <div className="hidden md:block">
-            <button type="button" onClick={handleToggleSidebar}>
-              <IoIosMenu />
-            </button>
-          </div>
-          <div className="block md:hidden">
-            <button type="button" onClick={handleToggleDrawer}>
-              <IoIosMenu />
-            </button>
-          </div>
-          <div className="block md:hidden">
-            <div css={styles.bussiness_logo}>
+          {!router.pathname.includes('/notifications') && (
+            <>
+              <div className="hidden md:block">
+                <button type="button" onClick={handleToggleSidebar}>
+                  <IoIosMenu />
+                </button>
+              </div>
+              <div className="block md:hidden">
+                <button type="button" onClick={handleToggleDrawer}>
+                  <IoIosMenu />
+                </button>
+              </div>
+              <div className="block md:hidden">
+                <div css={styles.bussiness_logo}>
+                  <Logo2Icon />
+                  <h1>Slackana</h1>
+                </div>
+              </div>
+            </>
+          )}
+          {router.pathname.includes('/notifications') && (
+            <button
+              css={styles.bussiness_logo}
+              className="px-3 py-2.5 outline-none"
+              onClick={() => router.push('/')}
+            >
               <Logo2Icon />
               <h1>Slackana</h1>
-            </div>
-          </div>
+            </button>
+          )}
         </div>
         <div css={styles.options}>
           <NotificationPopover />

--- a/client/src/components/templates/NotificationLayout/index.tsx
+++ b/client/src/components/templates/NotificationLayout/index.tsx
@@ -1,0 +1,37 @@
+import Head from 'next/head'
+import React, { useState } from 'react'
+import createPersistedState from 'use-persisted-state'
+
+import Header from '~/components/organisms/Header'
+import { styles } from '~/shared/twin/home-layout.styles'
+
+type Props = {
+  children: React.ReactNode
+  metaTitle: string
+}
+
+const useSidebarState = createPersistedState<boolean>('sidebarToggle')
+
+const Layout: React.FC<Props> = ({ children, metaTitle }): JSX.Element => {
+  const [isOpenSidebar, setIsOpenSidebar] = useSidebarState(true)
+  const [isOpenDrawer, setIsOpenDrawer] = useState<boolean>(false)
+
+  const handleToggleSidebar = (): void => setIsOpenSidebar(!isOpenSidebar)
+  const handleToggleDrawer = (): void => setIsOpenDrawer(!isOpenDrawer)
+
+  return (
+    <>
+      <Head>
+        <title key="notifications">{`Slackana | ${metaTitle}`}</title>
+      </Head>
+      <main css={styles.main}>
+        <Header actions={{ handleToggleSidebar, handleToggleDrawer }} />
+        <section css={styles.section}>
+          <div css={styles.content}>{children}</div>
+        </section>
+      </main>
+    </>
+  )
+}
+
+export default Layout

--- a/client/src/pages/notifications/projects/[id].tsx
+++ b/client/src/pages/notifications/projects/[id].tsx
@@ -1,0 +1,120 @@
+import Link from 'next/link'
+import { NextPage } from 'next'
+import { useState } from 'react'
+import { Hash } from 'react-feather'
+import { NextRouter, useRouter } from 'next/router'
+
+import { teams } from '~/shared/jsons/teams'
+import { globals } from '~/shared/twin/globals.styles'
+import Pagination from '~/components/atoms/Pagination'
+import { notifications } from '~/shared/jsons/notificationsData'
+import NotificationList from '~/components/molecules/NotificationList'
+import NotificationLayout from '~/components/templates/NotificationLayout'
+
+const Notifications: NextPage = (): JSX.Element => {
+  const router: NextRouter = useRouter()
+  const [pageNumber, setPageNumber] = useState<number>(0)
+
+  /*
+   * This is the logic for creating a custom pagination
+   */
+  const filesPerPage = 14
+  const pagesVisited = pageNumber * filesPerPage
+  const displayNotifications = notifications.slice(pagesVisited, pagesVisited + filesPerPage)
+  const pageCount = Math.ceil(teams.length / filesPerPage)
+  const changePage = ({ selected }: { selected: number }): void => setPageNumber(selected)
+
+  return (
+    <NotificationLayout metaTitle="Notifications">
+      <article className="flex h-full min-h-full w-full overflow-hidden text-slate-700">
+        {/*
+         * List of Projects
+         */}
+        <section className="flex max-w-[300px] flex-col py-8">
+          <h1 className="mb-4 hidden px-4 text-sm font-bold md:block">List of Projects</h1>
+          <nav className="hidden h-screen overflow-y-auto px-4 scrollbar-thin scrollbar-track-slate-100 scrollbar-thumb-slate-400 scrollbar-thumb-rounded-md md:block">
+            <ul className="flex flex-col space-y-1 text-sm">
+              {teams.map(({ id, name }) => (
+                <li key={id}>
+                  <Link href={`/notifications/projects/${id}`}>
+                    <a
+                      href="#"
+                      className={`
+                        flex w-full items-center space-x-2 rounded-md border border-transparent py-2 px-4 text-sm font-semibold
+                         text-slate-700 outline-none transition duration-75 ease-in-out hover:border-slate-200 hover:bg-slate-100 active:scale-95
+                        ${
+                          router.query.id == id.toString() &&
+                          `/notifications/projects/${id}` &&
+                          'bg-blue-600 !text-white hover:bg-blue-700'
+                        }
+                      `}
+                    >
+                      <Hash className="h-4 w-4 shrink-0" />
+                      <span className="line-clamp-1">{name}</span>
+                    </a>
+                  </Link>
+                </li>
+              ))}
+            </ul>
+          </nav>
+        </section>
+
+        {/*
+         * Notification Table List
+         */}
+        <section className="mx-auto flex w-full max-w-7xl flex-col space-y-2 py-6 px-2 md:px-4">
+          <article className="flex items-center justify-between space-x-2 overflow-x-auto px-4 md:justify-end">
+            <div className="block w-full md:hidden">
+              <select css={globals.form_control} className="w-full font-semibold">
+                {teams.map(({ id, name }) => (
+                  <option value={name} key={id} className="line-clamp-1">
+                    {name}
+                  </option>
+                ))}
+              </select>
+            </div>
+            <div className="shrink-0 divide-x divide-slate-300 overflow-hidden rounded-md border border-slate-300 text-sm text-slate-900">
+              <button
+                className={`
+                  w-16 overflow-hidden bg-slate-200 py-2 outline-none md:py-1.5
+                `}
+              >
+                All
+              </button>
+              <button
+                className={`
+                  w-16 overflow-hidden py-2 outline-none md:py-1.5
+                `}
+              >
+                Unread
+              </button>
+            </div>
+          </article>
+          <article className="mx-auto flex w-full max-w-7xl flex-1 flex-col justify-between overflow-hidden bg-white px-4 pb-4">
+            <header className="rounded-t-md border-x border-t border-slate-300 bg-slate-100 px-6 py-3">
+              <h1 className="text-sm font-semibold">Notifications</h1>
+            </header>
+            <main
+              className={`
+                h-full w-full max-w-full flex-1 overflow-auto rounded-b-md border-x border-b border-slate-300 bg-white 
+                scrollbar-thin scrollbar-thumb-slate-400 scrollbar-thumb-rounded-md
+              `}
+            >
+              <NotificationList notifications={displayNotifications} />
+            </main>
+            <footer className="mt-3 flex items-center justify-center ">
+              <Pagination
+                length={notifications?.length}
+                pageNumber={pageNumber}
+                pageCount={pageCount}
+                actions={{ changePage }}
+              />
+            </footer>
+          </article>
+        </section>
+      </article>
+    </NotificationLayout>
+  )
+}
+
+export default Notifications

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -89,3 +89,12 @@ export interface FileIcon {
   name: string
   Icon: any
 }
+
+export interface Notification {
+  id: string
+  name: string
+  notification_type: string
+  task_name?: string
+  link?: string
+  created_at: string
+}

--- a/client/src/shared/jsons/notificationsData.ts
+++ b/client/src/shared/jsons/notificationsData.ts
@@ -1,0 +1,196 @@
+import { Notification } from '../interfaces'
+
+export const notifications: Notification[] = [
+  {
+    id: '1',
+    name: 'Christofer Culhane',
+    notification_type: 'committed',
+    task_name: '#slacakana',
+    link: '/team/1/projects',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '2',
+    name: 'Joshua Galit',
+    notification_type: 'merged',
+    task_name: '[680-1] - [BugTask] Fix Protected Routes in Dev Server',
+    link: '/team/2/board?task_id=44',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '3',
+    name: 'Haylie Passaquindici Arcand',
+    notification_type: 'assigned',
+    task_name: '[495] - [FE] Indicate project name in the nudge notification',
+    link: '/team/3/board?task_id=65',
+    created_at: '2022-10-17 08:21:50'
+  },
+  {
+    id: '4',
+    name: 'Miracle Botosh',
+    notification_type: 'assigned',
+    task_name: '[491] - [FE] Additional icons for editable fields in the Project details',
+    link: '/team/4/board?task_id=45',
+    created_at: '2022-10-18 07:07:35'
+  },
+  {
+    id: '5',
+    name: 'Christofer Culhane',
+    notification_type: 'committed',
+    task_name: '#slacakana',
+    link: '/team/1/projects',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '6',
+    name: 'Joshua Galit',
+    notification_type: 'merged',
+    task_name: '[680-1] - [BugTask] Fix Protected Routes in Dev Server',
+    link: '/team/2/board?task_id=44',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '7',
+    name: 'Haylie Passaquindici Arcand',
+    notification_type: 'assigned',
+    task_name: '[495] - [FE] Indicate project name in the nudge notification',
+    link: '/team/3/board?task_id=65',
+    created_at: '2022-10-17 08:21:50'
+  },
+  {
+    id: '8',
+    name: 'Miracle Botosh',
+    notification_type: 'assigned',
+    task_name: '[491] - [FE] Additional icons for editable fields in the Project details',
+    link: '/team/4/board?task_id=45',
+    created_at: '2022-10-18 07:07:35'
+  },
+  {
+    id: '9',
+    name: 'Christofer Culhane',
+    notification_type: 'committed',
+    task_name: '#slacakana',
+    link: '/team/1/projects',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '10',
+    name: 'Joshua Galit',
+    notification_type: 'merged',
+    task_name: '[680-1] - [BugTask] Fix Protected Routes in Dev Server',
+    link: '/team/2/board?task_id=44',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '11',
+    name: 'Haylie Passaquindici Arcand',
+    notification_type: 'assigned',
+    task_name: '[495] - [FE] Indicate project name in the nudge notification',
+    link: '/team/3/board?task_id=65',
+    created_at: '2022-10-17 08:21:50'
+  },
+  {
+    id: '12',
+    name: 'Miracle Botosh',
+    notification_type: 'assigned',
+    task_name: '[491] - [FE] Additional icons for editable fields in the Project details',
+    link: '/team/4/board?task_id=45',
+    created_at: '2022-10-18 07:07:35'
+  },
+  {
+    id: '13',
+    name: 'Christofer Culhane',
+    notification_type: 'committed',
+    task_name: '#slacakana',
+    link: '/team/1/projects',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '14',
+    name: 'Joshua Galit',
+    notification_type: 'merged',
+    task_name: '[680-1] - [BugTask] Fix Protected Routes in Dev Server',
+    link: '/team/2/board?task_id=44',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '15',
+    name: 'Haylie Passaquindici Arcand',
+    notification_type: 'assigned',
+    task_name: '[495] - [FE] Indicate project name in the nudge notification',
+    link: '/team/3/board?task_id=65',
+    created_at: '2022-10-17 08:21:50'
+  },
+  {
+    id: '16',
+    name: 'Miracle Botosh',
+    notification_type: 'assigned',
+    task_name: '[491] - [FE] Additional icons for editable fields in the Project details',
+    link: '/team/4/board?task_id=45',
+    created_at: '2022-10-18 07:07:35'
+  },
+  {
+    id: '17',
+    name: 'Christofer Culhane',
+    notification_type: 'committed',
+    task_name: '#slacakana',
+    link: '/team/1/projects',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '18',
+    name: 'Joshua Galit',
+    notification_type: 'merged',
+    task_name: '[680-1] - [BugTask] Fix Protected Routes in Dev Server',
+    link: '/team/2/board?task_id=44',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '19',
+    name: 'Haylie Passaquindici Arcand',
+    notification_type: 'assigned',
+    task_name: '[495] - [FE] Indicate project name in the nudge notification',
+    link: '/team/3/board?task_id=65',
+    created_at: '2022-10-17 08:21:50'
+  },
+  {
+    id: '20',
+    name: 'Miracle Botosh',
+    notification_type: 'assigned',
+    task_name: '[491] - [FE] Additional icons for editable fields in the Project details',
+    link: '/team/4/board?task_id=45',
+    created_at: '2022-10-18 07:07:35'
+  },
+  {
+    id: '21',
+    name: 'Christofer Culhane',
+    notification_type: 'committed',
+    task_name: '#slacakana',
+    link: '/team/1/projects',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '22',
+    name: 'Joshua Galit',
+    notification_type: 'merged',
+    task_name: '[680-1] - [BugTask] Fix Protected Routes in Dev Server',
+    link: '/team/2/board?task_id=44',
+    created_at: '2022-10-14 11:31:05'
+  },
+  {
+    id: '23',
+    name: 'Haylie Passaquindici Arcand',
+    notification_type: 'assigned',
+    task_name: '[495] - [FE] Indicate project name in the nudge notification',
+    link: '/team/3/board?task_id=65',
+    created_at: '2022-10-17 08:21:50'
+  },
+  {
+    id: '24',
+    name: 'Miracle Botosh',
+    notification_type: 'assigned',
+    task_name: '[491] - [FE] Additional icons for editable fields in the Project details',
+    link: '/team/4/board?task_id=45',
+    created_at: '2022-10-18 07:07:35'
+  }
+]


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203247946500436/f

## Definition of Done
- [x]  Created Notification List Page Based on the Figma Design
- [x] Reused Table and Pagination Component

## Notes
Figma Design
- https://www.figma.com/file/RPsCfeJOXri9iYh3eOf1G6/Slackana?node-id=1709%3A2135

The notification list icon are based on the 3 main categories type
1.  assigned
2. merged
3. committed
To dynamically show the necessary text name extensions 

## Pre-condition
cli: `cd client`
- yarn dev || npm run dev
- Go to `notifications/projects/:id` page to view the design

## Expected Output
- It should show the List of Projects that you are part with
- Should be able to show the List of Notifications based on the project you are with

## Screenshots/Recordings
![newlice](https://user-images.githubusercontent.com/108642414/199624839-5e46b595-b8b1-44c7-96ff-80c75ae51d00.gif)

