### PR TITLE
[699] - [BugTask] Notification red dot must be gone after the user click the notification bell button and notification must be gone if the user open the task notification slider.

### DIFF
--- a/api/app/Http/Controllers/NotificationSeenController.php
+++ b/api/app/Http/Controllers/NotificationSeenController.php
@@ -1,0 +1,16 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use Illuminate\Http\Request;
+
+class NotificationSeenController extends Controller
+{
+  public function update(Request $request)
+  {
+    auth()->user()->notifications()->update([
+      'is_seen' => true
+    ]);
+    return response()->noContent();
+  }
+}

--- a/api/database/migrations/2022_11_02_071347_add_seen_at_column.php
+++ b/api/database/migrations/2022_11_02_071347_add_seen_at_column.php
@@ -1,0 +1,32 @@
+<?php
+
+use Illuminate\Database\Migrations\Migration;
+use Illuminate\Database\Schema\Blueprint;
+use Illuminate\Support\Facades\Schema;
+
+return new class extends Migration
+{
+  /**
+   * Run the migrations.
+   *
+   * @return void
+   */
+  public function up()
+  {
+    Schema::table('notifications', function (Blueprint $table) {
+      $table->boolean('is_seen')->default(false)->after('read_at');
+    });
+  }
+
+  /**
+   * Reverse the migrations.
+   *
+   * @return void
+   */
+  public function down()
+  {
+    Schema::table('notifications', function (Blueprint $table) {
+      $table->dropColumn('is_seen');
+    });
+  }
+};

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -6,6 +6,7 @@ use App\Http\Controllers\UpdateUserSettingsController;
 use App\Http\Controllers\ChangeUserPasswordController;
 use App\Http\Controllers\CompleteTaskController;
 use App\Http\Controllers\NotificationController;
+use App\Http\Controllers\NotificationSeenController;
 use App\Http\Controllers\NudgeMemberController;
 use App\Http\Controllers\ProjectController;
 use App\Http\Controllers\ProjectFileController;
@@ -61,6 +62,7 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
     Route::get('/{project}/member/{member}/nudge-member', [NudgeMemberController::class, 'show']);
     Route::put('/{project}/task/position', [TaskPositionController::class, 'update']);
     Route::put('/{project}/task/{task}/move-section', [TaskSectionController::class, 'update']);
+    Route::put('/notification/seen', [NotificationSeenController::class, 'update']);
   });
 
   Route::group(['prefix' => 'user'], function () {

--- a/client/src/components/molecules/TaskList/index.tsx
+++ b/client/src/components/molecules/TaskList/index.tsx
@@ -17,6 +17,7 @@ import { useMemberMethods } from '~/hooks/memberMethods'
 import { useProjectMethods } from '~/hooks/projectMethods'
 import MenuTransition from '~/components/templates/MenuTransition'
 import handleImageError from '~/helpers/handleImageError'
+import { useDebounceSearch } from '~/hooks/debounceSearch'
 
 type Props = {
   task: any
@@ -67,6 +68,8 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
   const { permissions, canComplete } = useProjectMethods(parseInt(id as string))
   const [isTaskCompleted, setIsTaskCompleted] = useState<any>(false)
   const [taskName, setTaskName] = useState<any>('')
+  const [search, setSearch] = useState<string>('')
+  const debouncedSearch = useDebounceSearch(search, 500)
   const {
     useHandleUpdateTaskDueDate,
     useHandleUpdateTaskAssignee,
@@ -127,19 +130,10 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
     setIsTaskCompleted(!isTaskCompleted)
     useHandleCompleteTask(task?.id)
   }
-  const onSearchChange = (e: any): void => {
-    const value = e.target.value
-    if (value.length === 0) {
-      filterMembersName(parseInt(id as string), value)
-    }
-  }
-  const onSearch = (e: any): void => {
-    const value = e.target.value
-    const isEnter = e.key === 'Enter' || e.keyCode === 13
 
-    if (!isEnter) return
-    filterMembersName(parseInt(id as string), value)
-  }
+  useEffect(() => {
+    filterMembersName(parseInt(id as string), search)
+  }, [debouncedSearch])
 
   let isBlur = true
   const [isEditing, setIsEditing] = useState(false)
@@ -220,8 +214,7 @@ const TaskList: React.FC<Props> = (props): JSX.Element => {
             <Search color="#94A3B8" />
             <input
               type="text"
-              onChange={onSearchChange}
-              onKeyDown={onSearch}
+              onChange={(e) => setSearch(e.target.value)}
               className="mr-5 w-full border-none text-slate-900 focus:ring-transparent"
               placeholder="Find members"
             />


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203283041831699/f

## Definition of Done
- [x] After user tap/click the notification bell button, red dot will be automatically gone.
- [x] If user tap/click the notification bell button it will open the task slider and notification tab will be gone and only open the task slider.

## Notes
- Please run `php artisan migrate` again as new column `is_seen` is added for notifications table

## Pre-condition
- Go to a project then go to boards
- Assign a task to someone
- Click the notification bell, then the notification itself

## Expected Output
- After user tap/click the notification bell button, red dot will be automatically gone.
- If user tap/click the notification bell button it will open the task slider and notification tab will be gone and only open the task slider.

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/199429620-f17a213d-d1a1-45c7-aa3c-5b1a08b379f1.mp4






