### PR TITLE
[705] - [BugTask] Can still assign the same member in the task even if the task is already assigned to that specific member. Also can receive notification.

### DIFF
--- a/api/app/Http/Controllers/TaskAssignmentController.php
+++ b/api/app/Http/Controllers/TaskAssignmentController.php
@@ -19,10 +19,13 @@ class TaskAssignmentController extends Controller
   public function update(Project $project, UpdateTaskAssignmentRequest $request, Task $task)
   {
     if ($this->isProjectOwner($project) || $this->isTeamLeader($project)) {
+      $taskMemberID = $task->project_member_id;
       $task->update($request->validated());
       $member = ProjectMember::with('user')->findOrFail($request->project_member_id);
-      Notification::send($member->user, new AssignTaskNotification(auth()->user()->id, $task->id, $project->id));
-      event(new AssignTaskEvent($member->user));
+      if (intval($taskMemberID) !== intval($request->project_member_id)) {
+        Notification::send($member->user, new AssignTaskNotification(auth()->user()->id, $task->id, $project->id));
+        event(new AssignTaskEvent($member->user));
+      }
       return response()->noContent();
     }
     return $this->unauthorizedAccess();


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203283041831705/f

## Definition of Done
- [x] The assignee can still be assigned in the same task but  should not be able to receive another notification in the same task

## Notes
- None

## Pre-condition
- Go to a project then go to boards
- Assign a task to someone
- Then check the notification bell
- Assign again the same person

## Expected Output
- Can still assign the same member in the same task but cannot receive another notification

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/199472660-af39817e-2996-4abb-8836-b6f2565fe57e.mp4







