### PR TITLE
[427] - [FE] Integrate Fetch, and Upload Files Functionality

### DIFF
--- a/api/app/Enums/PermissionEnum.php
+++ b/api/app/Enums/PermissionEnum.php
@@ -26,6 +26,10 @@ enum PermissionEnum: int
   case ASSIGN_TASK = 20;
   case SET_TASK_AS_COMPLETED = 21;
   case MOVE_TASK = 22;
+  case UPLOAD_FILE = 23;
+  case DELETE_FILE = 24;
+  case DOWNLOAD_FILE = 25;
+  case RENAME_FILE = 26;
 
   public function toString()
   {
@@ -52,6 +56,10 @@ enum PermissionEnum: int
       self::ASSIGN_TASK => 'assignTask',
       self::SET_TASK_AS_COMPLETED => 'setTaskAsCompleted',
       self::MOVE_TASK => 'moveTask',
+      self::UPLOAD_FILE => 'uploadFile',
+      self::DELETE_FILE => 'deleteFile',
+      self::DOWNLOAD_FILE => 'downloadFile',
+      self::RENAME_FILE => 'renameFile'
     };
   }
 }

--- a/api/app/Http/Controllers/ProjectFileController.php
+++ b/api/app/Http/Controllers/ProjectFileController.php
@@ -4,6 +4,7 @@ namespace App\Http\Controllers;
 
 use App\Http\Resources\ProjectFileResource;
 use Illuminate\Http\Request;
+use App\Http\Requests\StoreProjectFileRequest;
 use App\Models\Project;
 
 class ProjectFileController extends Controller
@@ -15,17 +16,17 @@ class ProjectFileController extends Controller
      */
     public function index(Project $project)
     {
-        return ProjectFileResource::collection($project->getMedia('project-files'));
+        return ProjectFileResource::collection($project->getMedia('project-files')->sortByDesc('created_at'));
     }
 
 
     /**
      * Store a newly created resource in storage.
      *
-     * @param  \Illuminate\Http\Request  $request
+     * @param  \App\Http\Requests\StoreProjectFileRequest $request
      * @return \Illuminate\Http\Response
      */
-    public function store(Request $request, Project $project)
+    public function store(StoreProjectFileRequest $request, Project $project)
     {
         if ($request->hasFile('file')) {
             $project->addMedia($request->file('file'))

--- a/api/app/Http/Requests/StoreProjectFileRequest.php
+++ b/api/app/Http/Requests/StoreProjectFileRequest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace App\Http\Requests;
+
+use Illuminate\Foundation\Http\FormRequest;
+
+
+class StoreProjectFileRequest extends FormRequest
+{
+  /**
+   * Determine if the user is authorized to make this request.
+   *
+   * @return bool
+   */
+  public function authorize()
+  {
+    return true;
+  }
+
+  /**
+   * Get the validation rules that apply to the request.
+   *
+   * @return array<string, mixed>
+   */
+  public function rules()
+  {
+    return [
+      'file' => 'required|file|max:10000',
+    ];
+  }
+
+  /**
+   * Get the error messages for the defined validation rules.
+   *
+   * @return array<string, string>
+   */
+
+  public function messages()
+  {
+    return [
+      'file.required' => 'A file is required',
+      'file.file' => 'A file must be a file',
+    ];
+  }
+}

--- a/api/composer.lock
+++ b/api/composer.lock
@@ -58,16 +58,16 @@
         },
         {
             "name": "aws/aws-sdk-php",
-            "version": "3.240.3",
+            "version": "3.240.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/aws/aws-sdk-php.git",
-                "reference": "2080f747489b2d4ca291dcfb8078db60dbb6c255"
+                "reference": "afad16e102229de8da15f07cc48436955811ef7f"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/2080f747489b2d4ca291dcfb8078db60dbb6c255",
-                "reference": "2080f747489b2d4ca291dcfb8078db60dbb6c255",
+                "url": "https://api.github.com/repos/aws/aws-sdk-php/zipball/afad16e102229de8da15f07cc48436955811ef7f",
+                "reference": "afad16e102229de8da15f07cc48436955811ef7f",
                 "shasum": ""
             },
             "require": {
@@ -146,9 +146,9 @@
             "support": {
                 "forum": "https://forums.aws.amazon.com/forum.jspa?forumID=80",
                 "issues": "https://github.com/aws/aws-sdk-php/issues",
-                "source": "https://github.com/aws/aws-sdk-php/tree/3.240.3"
+                "source": "https://github.com/aws/aws-sdk-php/tree/3.240.7"
             },
-            "time": "2022-10-26T18:17:08+00:00"
+            "time": "2022-11-01T18:23:34+00:00"
         },
         {
             "name": "brick/math",
@@ -208,16 +208,16 @@
         },
         {
             "name": "dflydev/dot-access-data",
-            "version": "v3.0.1",
+            "version": "v3.0.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/dflydev/dflydev-dot-access-data.git",
-                "reference": "0992cc19268b259a39e86f296da5f0677841f42c"
+                "reference": "f41715465d65213d644d3141a6a93081be5d3549"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/0992cc19268b259a39e86f296da5f0677841f42c",
-                "reference": "0992cc19268b259a39e86f296da5f0677841f42c",
+                "url": "https://api.github.com/repos/dflydev/dflydev-dot-access-data/zipball/f41715465d65213d644d3141a6a93081be5d3549",
+                "reference": "f41715465d65213d644d3141a6a93081be5d3549",
                 "shasum": ""
             },
             "require": {
@@ -228,7 +228,7 @@
                 "phpunit/phpunit": "^7.5 || ^8.5 || ^9.3",
                 "scrutinizer/ocular": "1.6.0",
                 "squizlabs/php_codesniffer": "^3.5",
-                "vimeo/psalm": "^3.14"
+                "vimeo/psalm": "^4.0.0"
             },
             "type": "library",
             "extra": {
@@ -277,9 +277,9 @@
             ],
             "support": {
                 "issues": "https://github.com/dflydev/dflydev-dot-access-data/issues",
-                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.1"
+                "source": "https://github.com/dflydev/dflydev-dot-access-data/tree/v3.0.2"
             },
-            "time": "2021-08-13T13:06:58+00:00"
+            "time": "2022-10-27T11:44:00+00:00"
         },
         {
             "name": "doctrine/inflector",
@@ -1194,16 +1194,16 @@
         },
         {
             "name": "laravel/framework",
-            "version": "v9.37.0",
+            "version": "v9.38.0",
             "source": {
                 "type": "git",
                 "url": "https://github.com/laravel/framework.git",
-                "reference": "0c9675abf6d966e834b2ebeca3319f524e07a330"
+                "reference": "abf198e443e06696af3f356b44de67c0fa516107"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/laravel/framework/zipball/0c9675abf6d966e834b2ebeca3319f524e07a330",
-                "reference": "0c9675abf6d966e834b2ebeca3319f524e07a330",
+                "url": "https://api.github.com/repos/laravel/framework/zipball/abf198e443e06696af3f356b44de67c0fa516107",
+                "reference": "abf198e443e06696af3f356b44de67c0fa516107",
                 "shasum": ""
             },
             "require": {
@@ -1376,7 +1376,7 @@
                 "issues": "https://github.com/laravel/framework/issues",
                 "source": "https://github.com/laravel/framework"
             },
-            "time": "2022-10-25T15:43:46+00:00"
+            "time": "2022-11-01T14:05:55+00:00"
         },
         {
             "name": "laravel/sanctum",
@@ -1573,16 +1573,16 @@
         },
         {
             "name": "league/commonmark",
-            "version": "2.3.5",
+            "version": "2.3.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/thephpleague/commonmark.git",
-                "reference": "84d74485fdb7074f4f9dd6f02ab957b1de513257"
+                "reference": "857afc47ce113454bd629037213378ba3219dd40"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/84d74485fdb7074f4f9dd6f02ab957b1de513257",
-                "reference": "84d74485fdb7074f4f9dd6f02ab957b1de513257",
+                "url": "https://api.github.com/repos/thephpleague/commonmark/zipball/857afc47ce113454bd629037213378ba3219dd40",
+                "reference": "857afc47ce113454bd629037213378ba3219dd40",
                 "shasum": ""
             },
             "require": {
@@ -1602,7 +1602,7 @@
                 "erusev/parsedown": "^1.0",
                 "ext-json": "*",
                 "github/gfm": "0.29.0",
-                "michelf/php-markdown": "^1.4",
+                "michelf/php-markdown": "^1.4 || ^2.0",
                 "nyholm/psr7": "^1.5",
                 "phpstan/phpstan": "^1.8.2",
                 "phpunit/phpunit": "^9.5.21",
@@ -1675,7 +1675,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-07-29T10:59:45+00:00"
+            "time": "2022-10-30T16:45:38+00:00"
         },
         {
             "name": "league/config",
@@ -2711,16 +2711,16 @@
         },
         {
             "name": "nunomaduro/termwind",
-            "version": "v1.14.1",
+            "version": "v1.14.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/nunomaduro/termwind.git",
-                "reference": "86fc30eace93b9b6d4c844ba6de76db84184e01b"
+                "reference": "9a8218511eb1a0965629ff820dda25985440aefc"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/86fc30eace93b9b6d4c844ba6de76db84184e01b",
-                "reference": "86fc30eace93b9b6d4c844ba6de76db84184e01b",
+                "url": "https://api.github.com/repos/nunomaduro/termwind/zipball/9a8218511eb1a0965629ff820dda25985440aefc",
+                "reference": "9a8218511eb1a0965629ff820dda25985440aefc",
                 "shasum": ""
             },
             "require": {
@@ -2777,7 +2777,7 @@
             ],
             "support": {
                 "issues": "https://github.com/nunomaduro/termwind/issues",
-                "source": "https://github.com/nunomaduro/termwind/tree/v1.14.1"
+                "source": "https://github.com/nunomaduro/termwind/tree/v1.14.2"
             },
             "funding": [
                 {
@@ -2793,7 +2793,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-10-17T15:20:29+00:00"
+            "time": "2022-10-28T22:51:32+00:00"
         },
         {
             "name": "paragonie/constant_time_encoding",
@@ -4194,16 +4194,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v6.1.6",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "7fa3b9cf17363468795e539231a5c91b02b608fc"
+                "reference": "a1282bd0c096e0bdb8800b104177e2ce404d8815"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/7fa3b9cf17363468795e539231a5c91b02b608fc",
-                "reference": "7fa3b9cf17363468795e539231a5c91b02b608fc",
+                "url": "https://api.github.com/repos/symfony/console/zipball/a1282bd0c096e0bdb8800b104177e2ce404d8815",
+                "reference": "a1282bd0c096e0bdb8800b104177e2ce404d8815",
                 "shasum": ""
             },
             "require": {
@@ -4270,7 +4270,7 @@
                 "terminal"
             ],
             "support": {
-                "source": "https://github.com/symfony/console/tree/v6.1.6"
+                "source": "https://github.com/symfony/console/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -4286,7 +4286,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-07T08:04:03+00:00"
+            "time": "2022-10-26T21:42:49+00:00"
         },
         {
             "name": "symfony/css-selector",
@@ -4422,16 +4422,16 @@
         },
         {
             "name": "symfony/error-handler",
-            "version": "v6.1.6",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/error-handler.git",
-                "reference": "49f718e41f1b6f0fd5730895ca5b1c37defd828d"
+                "reference": "699a26ce5ec656c198bf6e26398b0f0818c7e504"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/error-handler/zipball/49f718e41f1b6f0fd5730895ca5b1c37defd828d",
-                "reference": "49f718e41f1b6f0fd5730895ca5b1c37defd828d",
+                "url": "https://api.github.com/repos/symfony/error-handler/zipball/699a26ce5ec656c198bf6e26398b0f0818c7e504",
+                "reference": "699a26ce5ec656c198bf6e26398b0f0818c7e504",
                 "shasum": ""
             },
             "require": {
@@ -4473,7 +4473,7 @@
             "description": "Provides tools to manage errors and ease debugging PHP code",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/error-handler/tree/v6.1.6"
+                "source": "https://github.com/symfony/error-handler/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -4489,7 +4489,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-07T08:04:03+00:00"
+            "time": "2022-10-28T16:23:08+00:00"
         },
         {
             "name": "symfony/event-dispatcher",
@@ -4719,16 +4719,16 @@
         },
         {
             "name": "symfony/http-foundation",
-            "version": "v6.1.6",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-foundation.git",
-                "reference": "3ae8e9c57155fc48930493a629da293b32efbde0"
+                "reference": "792a1856d2b95273f0e1c3435785f1d01a60ecc6"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/3ae8e9c57155fc48930493a629da293b32efbde0",
-                "reference": "3ae8e9c57155fc48930493a629da293b32efbde0",
+                "url": "https://api.github.com/repos/symfony/http-foundation/zipball/792a1856d2b95273f0e1c3435785f1d01a60ecc6",
+                "reference": "792a1856d2b95273f0e1c3435785f1d01a60ecc6",
                 "shasum": ""
             },
             "require": {
@@ -4774,7 +4774,7 @@
             "description": "Defines an object-oriented layer for the HTTP specification",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-foundation/tree/v6.1.6"
+                "source": "https://github.com/symfony/http-foundation/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -4790,20 +4790,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-02T08:30:52+00:00"
+            "time": "2022-10-12T09:44:59+00:00"
         },
         {
             "name": "symfony/http-kernel",
-            "version": "v6.1.6",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/http-kernel.git",
-                "reference": "102f99bf81799e93f61b9a73b2f38b309c587a94"
+                "reference": "8fc1ffe753948c47a103a809cdd6a4a8458b3254"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/102f99bf81799e93f61b9a73b2f38b309c587a94",
-                "reference": "102f99bf81799e93f61b9a73b2f38b309c587a94",
+                "url": "https://api.github.com/repos/symfony/http-kernel/zipball/8fc1ffe753948c47a103a809cdd6a4a8458b3254",
+                "reference": "8fc1ffe753948c47a103a809cdd6a4a8458b3254",
                 "shasum": ""
             },
             "require": {
@@ -4884,7 +4884,7 @@
             "description": "Provides a structured process for converting a Request into a Response",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/http-kernel/tree/v6.1.6"
+                "source": "https://github.com/symfony/http-kernel/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -4900,20 +4900,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-12T07:48:47+00:00"
+            "time": "2022-10-28T18:06:36+00:00"
         },
         {
             "name": "symfony/mailer",
-            "version": "v6.1.5",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mailer.git",
-                "reference": "e1b32deb9efc48def0c76b876860ad36f2123e89"
+                "reference": "7e19813c0b43387c55665780c4caea505cc48391"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mailer/zipball/e1b32deb9efc48def0c76b876860ad36f2123e89",
-                "reference": "e1b32deb9efc48def0c76b876860ad36f2123e89",
+                "url": "https://api.github.com/repos/symfony/mailer/zipball/7e19813c0b43387c55665780c4caea505cc48391",
+                "reference": "7e19813c0b43387c55665780c4caea505cc48391",
                 "shasum": ""
             },
             "require": {
@@ -4958,7 +4958,7 @@
             "description": "Helps sending emails",
             "homepage": "https://symfony.com",
             "support": {
-                "source": "https://github.com/symfony/mailer/tree/v6.1.5"
+                "source": "https://github.com/symfony/mailer/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -4974,20 +4974,20 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-08-29T06:58:39+00:00"
+            "time": "2022-10-28T16:23:08+00:00"
         },
         {
             "name": "symfony/mime",
-            "version": "v6.1.6",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/mime.git",
-                "reference": "5ae192b9a39730435cfec025a499f79d05ac68a3"
+                "reference": "f440f066d57691088d998d6e437ce98771144618"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/mime/zipball/5ae192b9a39730435cfec025a499f79d05ac68a3",
-                "reference": "5ae192b9a39730435cfec025a499f79d05ac68a3",
+                "url": "https://api.github.com/repos/symfony/mime/zipball/f440f066d57691088d998d6e437ce98771144618",
+                "reference": "f440f066d57691088d998d6e437ce98771144618",
                 "shasum": ""
             },
             "require": {
@@ -4999,8 +4999,7 @@
                 "egulias/email-validator": "~3.0.0",
                 "phpdocumentor/reflection-docblock": "<3.2.2",
                 "phpdocumentor/type-resolver": "<1.4.0",
-                "symfony/mailer": "<5.4",
-                "symfony/serializer": "<5.4.14|>=6.0,<6.0.14|>=6.1,<6.1.6"
+                "symfony/mailer": "<5.4"
             },
             "require-dev": {
                 "egulias/email-validator": "^2.1.10|^3.1",
@@ -5008,7 +5007,7 @@
                 "symfony/dependency-injection": "^5.4|^6.0",
                 "symfony/property-access": "^5.4|^6.0",
                 "symfony/property-info": "^5.4|^6.0",
-                "symfony/serializer": "^5.4.14|~6.0.14|^6.1.6"
+                "symfony/serializer": "^5.2|^6.0"
             },
             "type": "library",
             "autoload": {
@@ -5040,7 +5039,7 @@
                 "mime-type"
             ],
             "support": {
-                "source": "https://github.com/symfony/mime/tree/v6.1.6"
+                "source": "https://github.com/symfony/mime/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -5056,7 +5055,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-10-07T08:04:03+00:00"
+            "time": "2022-10-19T08:10:53+00:00"
         },
         {
             "name": "symfony/polyfill-ctype",
@@ -5858,16 +5857,16 @@
         },
         {
             "name": "symfony/routing",
-            "version": "v6.1.5",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/routing.git",
-                "reference": "f8c1ebb43d0f39e5ecd12a732ba1952a3dd8455c"
+                "reference": "95effeb9d6e2cec861cee06bf5bbf82d09aea7f5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/routing/zipball/f8c1ebb43d0f39e5ecd12a732ba1952a3dd8455c",
-                "reference": "f8c1ebb43d0f39e5ecd12a732ba1952a3dd8455c",
+                "url": "https://api.github.com/repos/symfony/routing/zipball/95effeb9d6e2cec861cee06bf5bbf82d09aea7f5",
+                "reference": "95effeb9d6e2cec861cee06bf5bbf82d09aea7f5",
                 "shasum": ""
             },
             "require": {
@@ -5926,7 +5925,7 @@
                 "url"
             ],
             "support": {
-                "source": "https://github.com/symfony/routing/tree/v6.1.5"
+                "source": "https://github.com/symfony/routing/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -5942,7 +5941,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-09T09:26:14+00:00"
+            "time": "2022-10-18T13:12:43+00:00"
         },
         {
             "name": "symfony/service-contracts",
@@ -6031,16 +6030,16 @@
         },
         {
             "name": "symfony/string",
-            "version": "v6.1.6",
+            "version": "v6.1.7",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/string.git",
-                "reference": "7e7e0ff180d4c5a6636eaad57b65092014b61864"
+                "reference": "823f143370880efcbdfa2dbca946b3358c4707e5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/string/zipball/7e7e0ff180d4c5a6636eaad57b65092014b61864",
-                "reference": "7e7e0ff180d4c5a6636eaad57b65092014b61864",
+                "url": "https://api.github.com/repos/symfony/string/zipball/823f143370880efcbdfa2dbca946b3358c4707e5",
+                "reference": "823f143370880efcbdfa2dbca946b3358c4707e5",
                 "shasum": ""
             },
             "require": {
@@ -6096,7 +6095,7 @@
                 "utf8"
             ],
             "support": {
-                "source": "https://github.com/symfony/string/tree/v6.1.6"
+                "source": "https://github.com/symfony/string/tree/v6.1.7"
             },
             "funding": [
                 {
@@ -7435,16 +7434,16 @@
         },
         {
             "name": "phpunit/php-code-coverage",
-            "version": "9.2.17",
+            "version": "9.2.18",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/php-code-coverage.git",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8"
+                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/aa94dc41e8661fe90c7316849907cba3007b10d8",
-                "reference": "aa94dc41e8661fe90c7316849907cba3007b10d8",
+                "url": "https://api.github.com/repos/sebastianbergmann/php-code-coverage/zipball/12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
+                "reference": "12fddc491826940cf9b7e88ad9664cf51f0f6d0a",
                 "shasum": ""
             },
             "require": {
@@ -7500,7 +7499,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/php-code-coverage/issues",
-                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.17"
+                "source": "https://github.com/sebastianbergmann/php-code-coverage/tree/9.2.18"
             },
             "funding": [
                 {
@@ -7508,7 +7507,7 @@
                     "type": "github"
                 }
             ],
-            "time": "2022-08-30T12:24:04+00:00"
+            "time": "2022-10-27T13:35:33+00:00"
         },
         {
             "name": "phpunit/php-file-iterator",
@@ -7753,16 +7752,16 @@
         },
         {
             "name": "phpunit/phpunit",
-            "version": "9.5.25",
+            "version": "9.5.26",
             "source": {
                 "type": "git",
                 "url": "https://github.com/sebastianbergmann/phpunit.git",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d"
+                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
-                "reference": "3e6f90ca7e3d02025b1d147bd8d4a89fd4ca8a1d",
+                "url": "https://api.github.com/repos/sebastianbergmann/phpunit/zipball/851867efcbb6a1b992ec515c71cdcf20d895e9d2",
+                "reference": "851867efcbb6a1b992ec515c71cdcf20d895e9d2",
                 "shasum": ""
             },
             "require": {
@@ -7835,7 +7834,7 @@
             ],
             "support": {
                 "issues": "https://github.com/sebastianbergmann/phpunit/issues",
-                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.25"
+                "source": "https://github.com/sebastianbergmann/phpunit/tree/9.5.26"
             },
             "funding": [
                 {
@@ -7851,7 +7850,7 @@
                     "type": "tidelift"
                 }
             ],
-            "time": "2022-09-25T03:44:45+00:00"
+            "time": "2022-10-28T06:00:21+00:00"
         },
         {
             "name": "sebastian/cli-parser",

--- a/api/database/seeders/PermissionRolesSeeder.php
+++ b/api/database/seeders/PermissionRolesSeeder.php
@@ -39,6 +39,10 @@ class PermissionRolesSeeder extends Seeder
       ['permission_id' => PermissionEnum::ASSIGN_TASK],
       ['permission_id' => PermissionEnum::SET_TASK_AS_COMPLETED],
       ['permission_id' => PermissionEnum::MOVE_TASK],
+      ['permission_id' => PermissionEnum::UPLOAD_FILE],
+      ['permission_id' => PermissionEnum::DOWNLOAD_FILE],
+      ['permission_id' => PermissionEnum::DELETE_FILE],
+      ['permission_id' => PermissionEnum::RENAME_FILE],
     ]);
 
     $teamLeader = Role::find(RoleEnum::TEAM_LEADER)->permissions();
@@ -60,6 +64,10 @@ class PermissionRolesSeeder extends Seeder
       ['permission_id' => PermissionEnum::ASSIGN_TASK],
       ['permission_id' => PermissionEnum::SET_TASK_AS_COMPLETED],
       ['permission_id' => PermissionEnum::MOVE_TASK],
+      ['permission_id' => PermissionEnum::UPLOAD_FILE],
+      ['permission_id' => PermissionEnum::DOWNLOAD_FILE],
+      ['permission_id' => PermissionEnum::DELETE_FILE],
+      ['permission_id' => PermissionEnum::RENAME_FILE],
     ]);
 
     $member = Role::find(RoleEnum::MEMBER)->permissions();
@@ -67,6 +75,7 @@ class PermissionRolesSeeder extends Seeder
       ['permission_id' => PermissionEnum::LEAVE_PROJECT],
       ['permission_id' => PermissionEnum::SET_TASK_AS_COMPLETED],
       ['permission_id' => PermissionEnum::MOVE_TASK],
+      ['permission_id' => PermissionEnum::DOWNLOAD_FILE]
     ]);
   }
 }

--- a/api/database/seeders/PermissionSeeder.php
+++ b/api/database/seeders/PermissionSeeder.php
@@ -104,6 +104,22 @@ class PermissionSeeder extends Seeder
         'id' => PermissionEnum::MOVE_TASK,
         'name' => PermissionEnum::tryFrom(PermissionEnum::MOVE_TASK->value)->toString(),
       ],
+      [
+        'id' => PermissionEnum::UPLOAD_FILE,
+        'name' => PermissionEnum::tryFrom(PermissionEnum::UPLOAD_FILE->value)->toString(),
+      ],
+      [
+        'id' => PermissionEnum::DOWNLOAD_FILE,
+        'name' => PermissionEnum::tryFrom(PermissionEnum::DOWNLOAD_FILE->value)->toString(),
+      ],
+      [
+        'id' => PermissionEnum::DELETE_FILE,
+        'name' => PermissionEnum::tryFrom(PermissionEnum::DELETE_FILE->value)->toString(),
+      ],
+      [
+        'id' => PermissionEnum::RENAME_FILE,
+        'name' => PermissionEnum::tryFrom(PermissionEnum::RENAME_FILE->value)->toString(),
+      ]
     ];
     Permission::upsert($permissions, ['id'], ['name']);
   }

--- a/client/src/components/molecules/FileList/FIleItem.tsx
+++ b/client/src/components/molecules/FileList/FIleItem.tsx
@@ -5,6 +5,7 @@ import { Edit3, Trash, Download } from 'react-feather'
 import { Filename } from '~/shared/types'
 import { File } from '~/shared/interfaces'
 import { fileIconType } from '~/shared/jsons/fileIconType'
+import { useAppSelector } from '~/hooks/reduxSelector'
 
 const ReactTooltip = dynamic(() => import('react-tooltip'), { ssr: false })
 
@@ -21,6 +22,8 @@ const FileItem: FC<Props> = (props): JSX.Element => {
     file: { id, filename, size, type, date_upload },
     actions: { handleOpenEditModal, handleDeleteFile }
   } = props
+
+  const { userPermission: can } = useAppSelector((state) => state.project)
 
   const data = {
     id,
@@ -55,7 +58,7 @@ const FileItem: FC<Props> = (props): JSX.Element => {
           `}
         >
           <button
-            className="outline-none active:scale-95"
+            className={`outline-none active:scale-95 ${can?.renameFile ? '' : 'hidden'}`}
             data-for="actions"
             data-tip="Edit"
             onClick={() => handleOpenEditModal(data)}
@@ -63,14 +66,18 @@ const FileItem: FC<Props> = (props): JSX.Element => {
             <Edit3 className="h-4 w-4 md:h-5 md:w-5" />
           </button>
           <button
-            className="outline-none active:scale-95"
+            className={`outline-none active:scale-95 ${can?.deleteFile ? '' : 'hidden'}`}
             data-for="actions"
             data-tip="Delete"
             onClick={() => handleDeleteFile(id)}
           >
             <Trash className="h-4 w-4 md:h-5 md:w-5" />
           </button>
-          <button className="outline-none active:scale-95" data-for="actions" data-tip="Download">
+          <button
+            className={`outline-none active:scale-95 ${can?.downloadFile ? '' : 'hidden'}`}
+            data-for="actions"
+            data-tip="Download"
+          >
             <Download className="h-4 w-4 md:h-5 md:w-5" />
           </button>
           <ReactTooltip

--- a/client/src/components/molecules/FileList/index.tsx
+++ b/client/src/components/molecules/FileList/index.tsx
@@ -1,10 +1,12 @@
 import React, { FC } from 'react'
 
 import FileItem from './FIleItem'
+import { BlankSlateTableIcon } from '~/shared/icons/BlankSlateTableIcon'
 import TableHead from './TableHead'
 import { Filename } from '~/shared/types'
 import { File } from '~/shared/interfaces'
 import EditFilenameDialog from './EditFilenameDialog'
+import FileListSkeleton from '../FileListSkeleton'
 
 type Props = {
   isOpen: boolean
@@ -15,6 +17,18 @@ type Props = {
     handleDeleteFile: (id: string) => Promise<void>
     handleUpdateFilename: (data: Filename) => Promise<void>
   }
+  isUpdating: boolean
+  length: number
+}
+
+const BlankTable = (): JSX.Element => {
+  return (
+    <div className="flex h-full w-full flex-col items-center justify-center py-5">
+      <BlankSlateTableIcon />
+      <p className="mt-2 text-center text-slate-500">No files added to this project yet. </p>
+      <p className="text-center text-slate-500">Add a file by clicking the upload a file button.</p>
+    </div>
+  )
 }
 
 const FileList: FC<Props> = (props): JSX.Element => {
@@ -23,10 +37,16 @@ const FileList: FC<Props> = (props): JSX.Element => {
   const {
     isOpen,
     filename,
-    actions: { handleOpenEditModal, handleDeleteFile, handleUpdateFilename }
+    actions: { handleOpenEditModal, handleDeleteFile, handleUpdateFilename },
+    length
   } = props
 
-  return (
+  return props.isUpdating ? (
+    // Conditionally set the length of the skeleton if there are no files
+    <FileListSkeleton length={length + 1} />
+  ) : length === 0 ? (
+    <BlankTable />
+  ) : (
     <table className="w-full divide-y divide-slate-300 border-t border-slate-300 text-left text-sm leading-normal">
       <TableHead />
       <tbody className="divide-y divide-slate-300 text-sm text-slate-600">

--- a/client/src/components/molecules/FileListSkeleton/index.tsx
+++ b/client/src/components/molecules/FileListSkeleton/index.tsx
@@ -1,0 +1,49 @@
+import React, { FC } from 'react'
+import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
+
+type FileSkeletonProps = {
+  length: number
+}
+
+const FileListSkeleton: FC<FileSkeletonProps> = ({ length }): JSX.Element => {
+  return (
+    <table className="w-full divide-y divide-slate-300 border-t border-slate-300 text-left text-sm leading-normal">
+      <thead>
+        <tr className="bg-slate-50">
+          <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+            Filename
+          </th>
+          <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+            Size
+          </th>
+          <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+            Date
+          </th>
+          <th className="px-6 py-3 text-left text-xs font-medium uppercase tracking-wider text-slate-600">
+            Action
+          </th>
+        </tr>
+      </thead>
+      <tbody className="divide-y divide-slate-300 text-sm text-slate-600">
+        {Array.from({ length }, (_, i) => (
+          <tr key={i}>
+            <td className="whitespace-nowrap px-6 py-4">
+              <LineSkeleton />
+            </td>
+            <td className="whitespace-nowrap px-6 py-4">
+              <LineSkeleton />
+            </td>
+            <td className="whitespace-nowrap px-6 py-4">
+              <LineSkeleton />
+            </td>
+            <td className="whitespace-nowrap px-6 py-4">
+              <LineSkeleton />
+            </td>
+          </tr>
+        ))}
+      </tbody>
+    </table>
+  )
+}
+
+export default FileListSkeleton

--- a/client/src/components/molecules/PaginationSkeleton/index.tsx
+++ b/client/src/components/molecules/PaginationSkeleton/index.tsx
@@ -1,0 +1,23 @@
+import React, { FC } from 'react'
+
+import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
+
+const PaginationSkeleton: FC = (): JSX.Element => {
+  return (
+    <section className="paginate-section text-gray-500">
+      <div className="inline-flex -space-x-px text-sm">
+        <div className="paginate-link rounded-l-md">
+          <LineSkeleton />
+        </div>
+        <div className="paginate-link">
+          <LineSkeleton />
+        </div>
+        <div className="paginate-link rounded-l-md">
+          <LineSkeleton />
+        </div>
+      </div>
+    </section>
+  )
+}
+
+export default PaginationSkeleton

--- a/client/src/hooks/fileMethods.ts
+++ b/client/src/hooks/fileMethods.ts
@@ -1,0 +1,59 @@
+import { useEffect, useState } from 'react'
+
+import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
+
+import {
+  getProjectFiles,
+  addProjectFile,
+  deleteProjectFile,
+  renameProjectFile
+} from '~/redux/files/fileSlice'
+
+export const useFileMethods = (projectID: number) => {
+  const [isFileLoading, setIsFileLoading] = useState(false)
+  const dispatch = useAppDispatch()
+  const files = useAppSelector((state) => state.file.files)
+  const isLoading = useAppSelector((state) => state.file.isLoading)
+
+  useEffect(() => {
+    setIsFileLoading(true)
+    dispatch(getProjectFiles(projectID)).then((_) => setIsFileLoading(false))
+  }, [projectID])
+
+  const useHandleCreateFiles = async (data: any, callback: () => void): Promise<void> => {
+    setIsFileLoading(true)
+    dispatch(addProjectFile({ projectId: projectID, file: data })).then((_) => {
+      setIsFileLoading(false)
+      callback()
+    })
+  }
+
+  const useHandleDeleteFile = async (fileID: string, callback: () => void): Promise<void> => {
+    setIsFileLoading(true)
+    dispatch(deleteProjectFile({ projectId: projectID, fileId: fileID })).then((_) => {
+      setIsFileLoading(false)
+      callback()
+    })
+  }
+
+  const useHandleRenameFile = async (
+    fileID: string,
+    name: string,
+    callback: () => void
+  ): Promise<void> => {
+    setIsFileLoading(true)
+    dispatch(renameProjectFile({ projectId: projectID, fileId: fileID, name })).then((_) => {
+      setIsFileLoading(false)
+      callback()
+    })
+  }
+
+  return {
+    useHandleCreateFiles,
+    useHandleDeleteFile,
+    useHandleRenameFile,
+    isFileLoading,
+    isLoading,
+    files
+  }
+}

--- a/client/src/pages/team/[id]/files.tsx
+++ b/client/src/pages/team/[id]/files.tsx
@@ -1,14 +1,27 @@
 import { NextPage } from 'next'
+import { useRouter } from 'next/router'
 import React, { useState } from 'react'
 import { Upload, Link2 as LinkIcon } from 'react-feather'
-
 import { Filename } from '~/shared/types'
-import { files } from '~/shared/jsons/filesData'
 import FileList from '~/components/molecules/FileList'
 import Pagination from '~/components/atoms/Pagination'
+import PaginationSkeleton from '~/components/molecules/PaginationSkeleton'
 import ProjectLayout from '~/components/templates/ProjectLayout'
+import { darkToaster } from '~/utils/darkToaster'
+import { useFileMethods } from '~/hooks/fileMethods'
+import { useAppSelector } from '~/hooks/reduxSelector'
 
 const Files: NextPage = (): JSX.Element => {
+  const router = useRouter()
+  const { id: projectIDFiles } = router.query
+  const {
+    isLoading: isFileMethodLoading,
+    files,
+    useHandleCreateFiles,
+    useHandleRenameFile,
+    useHandleDeleteFile
+  } = useFileMethods(parseInt(projectIDFiles as string))
+
   const [pageNumber, setPageNumber] = useState<number>(0)
   const [isOpen, setIsOpen] = useState<boolean>(false)
   /*
@@ -32,7 +45,11 @@ const Files: NextPage = (): JSX.Element => {
    * This is the toggle for Edit Modal
    */
   const handleOpenEditModal = (data?: Filename): void => {
-    setFilename(data)
+    // set filename to be edited, remove the extension
+    setFilename({
+      id: data?.id,
+      filename: data?.filename?.split('.')[0]
+    })
     setIsOpen(!isOpen)
   }
 
@@ -40,7 +57,9 @@ const Files: NextPage = (): JSX.Element => {
    * Handle Update Filename
    */
   const handleUpdateFilename = async (data: Filename): Promise<void> => {
-    alert(JSON.stringify(data, null, 2))
+    useHandleRenameFile(filename.id, data.filename, () => {
+      darkToaster('File renamed successfully!', '✅')
+    })
     handleOpenEditModal()
   }
 
@@ -49,14 +68,19 @@ const Files: NextPage = (): JSX.Element => {
    */
   const handleDeleteFile = async (id: string): Promise<void> => {
     if (confirm('Do you want to delete?')) {
-      alert(`deleted ${id}`)
+      useHandleDeleteFile(id, () => {
+        darkToaster('File delete success!', '✅')
+      })
     }
   }
 
   return (
     <ProjectLayout metaTitle="Files">
       <section className="mx-auto flex w-full max-w-7xl flex-col justify-between overflow-hidden bg-white px-4 pt-5 pb-4">
-        <FileHeader />
+        <FileHeader
+          useHandleCreateFiles={useHandleCreateFiles}
+          isSubmitting={isFileMethodLoading}
+        />
         <main
           className={`
             h-full overflow-y-auto rounded-b-md border-x border-b border-slate-300 bg-white 
@@ -76,6 +100,8 @@ const Files: NextPage = (): JSX.Element => {
             filename={filename}
             files={displayFiles}
             actions={{ handleOpenEditModal, handleDeleteFile, handleUpdateFilename }}
+            isUpdating={isFileMethodLoading}
+            length={files.length}
           />
         </main>
         <footer className="mt-3 flex items-center justify-center ">
@@ -83,12 +109,18 @@ const Files: NextPage = (): JSX.Element => {
            * This will render
            * the table pagination
            */}
-          <Pagination
-            length={files?.length}
-            pageNumber={pageNumber}
-            pageCount={pageCount}
-            actions={{ changePage }}
-          />
+          {pageCount > 1 ? (
+            isFileMethodLoading ? (
+              <PaginationSkeleton />
+            ) : (
+              <Pagination
+                length={files?.length}
+                pageNumber={pageNumber}
+                pageCount={pageCount}
+                actions={{ changePage }}
+              />
+            )
+          ) : null}
         </footer>
       </section>
     </ProjectLayout>
@@ -100,7 +132,40 @@ const Files: NextPage = (): JSX.Element => {
  * - List of Files
  * - Upload Files button
  */
-const FileHeader = (): JSX.Element => {
+type FileHeaderProps = {
+  useHandleCreateFiles: (data: any, callback: () => void) => Promise<void>
+  isSubmitting: boolean
+}
+
+const FileHeader = (props: FileHeaderProps): JSX.Element => {
+  const error = useAppSelector((state) => state.file.error)
+  const isError = useAppSelector((state) => state.file.isError)
+  const { userPermission: can } = useAppSelector((state) => state.project)
+
+  /*
+   * Add files
+   */
+  const { useHandleCreateFiles, isSubmitting } = props
+  const hiddenFileInput = React.useRef<HTMLInputElement>(null)
+  const handleClick = (): void => {
+    hiddenFileInput.current?.click()
+  }
+
+  const handleChange = (e: React.ChangeEvent<HTMLInputElement>): void => {
+    const fileUploaded = e.target.files?.[0]
+
+    if (fileUploaded && !isSubmitting) {
+      useHandleCreateFiles(fileUploaded, () => {
+        if (isError) {
+          darkToaster(`${error.content}`, '❌')
+        } else {
+          darkToaster('File uploaded successfully!', '✅')
+        }
+        e.target.value = ''
+      })
+    }
+  }
+
   return (
     <header
       className={`
@@ -112,19 +177,28 @@ const FileHeader = (): JSX.Element => {
         <LinkIcon className="h-5 w-5" />
         <h1 className="text-sm font-medium">List of Files</h1>
       </div>
-      <label
-        htmlFor="upload"
-        className={`
+      {can?.uploadFile ? (
+        <label
+          htmlFor="upload"
+          className={`
           flex cursor-pointer items-center rounded border border-blue-700 bg-blue-600 px-2 py-[0.26rem] text-sm text-white
           shadow outline-none transition duration-150 ease-in-out focus:bg-blue-600 hover:bg-blue-700 active:scale-95 
-        `}
-      >
-        <input type="file" id="upload" className="hidden" />
-        <Upload className="mr-2 h-4 w-4" />
-        Upload Files
-      </label>
+        ${isSubmitting ? 'hidden' : ''}`}
+        >
+          <input
+            type="file"
+            ref={hiddenFileInput}
+            onChange={handleChange}
+            id="upload"
+            className="hidden"
+          />
+          <Upload className="mr-2 h-4 w-4" onClick={handleClick} />
+          Upload a file
+        </label>
+      ) : null}
     </header>
   )
 }
 
+export { authCheck as getServerSideProps } from '~/utils/getServerSideProps'
 export default Files

--- a/client/src/redux/files/fileService.ts
+++ b/client/src/redux/files/fileService.ts
@@ -1,0 +1,49 @@
+import { axios } from '~/shared/lib/axios'
+import { ProjectFileType } from '~/redux/files/fileType'
+
+const getProjectFiles = async (projectId: number): Promise<Array<ProjectFileType> | string> => {
+  const response = await axios.get(`/api/project/${projectId}/file`)
+  return response.data
+}
+
+const getProjectFile = async (projectId: number, fileId: string): Promise<Blob | string> => {
+  const response = await axios.get(`/api/project/${projectId}/file/${fileId}`, {
+    responseType: 'blob'
+  })
+  return response.data
+}
+
+const addProjectFile = async (projectId: number, file: any): Promise<string> => {
+  try {
+    const formData = new FormData()
+    formData.append('file', file)
+    const response = await axios.post(`/api/project/${projectId}/file`, formData)
+    return response.data.message
+  } catch (error: unknown) {
+    return 'Unprocessable Content'
+  }
+}
+
+const renameProjectFile = async (
+  projectId: number,
+  fileId: string,
+  name: string
+): Promise<string> => {
+  const response = await axios.put(`/api/project/${projectId}/file/${fileId}`, { name })
+  return response.data.message
+}
+
+const deleteProjectFile = async (projectId: number, fileId: string): Promise<string> => {
+  const response = await axios.delete(`/api/project/${projectId}/file/${fileId}`)
+  return response.data.message
+}
+
+const fileService = {
+  getProjectFiles,
+  getProjectFile,
+  addProjectFile,
+  renameProjectFile,
+  deleteProjectFile
+}
+
+export default fileService

--- a/client/src/redux/files/fileSlice.ts
+++ b/client/src/redux/files/fileSlice.ts
@@ -1,0 +1,199 @@
+import {
+  createSlice,
+  PayloadAction,
+  createAsyncThunk,
+  ActionReducerMapBuilder
+} from '@reduxjs/toolkit'
+
+import fileService from './fileService'
+import { FileStateType } from './fileType'
+import { catchError } from '~/utils/handleAxiosError'
+import formatFiles from '~/utils/formatFiles'
+
+const initialState: FileStateType = {
+  files: [],
+  isError: false,
+  isLoading: false,
+  isSuccess: false,
+  error: {
+    status: 0,
+    content: null
+  }
+}
+
+export const getProjectFiles = createAsyncThunk(
+  'file/getProjectFiles',
+  async (projectId: number, thunkAPI) => {
+    try {
+      const response = await fileService.getProjectFiles(projectId)
+      const files = formatFiles(response)
+      return files
+    } catch (error) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
+export const getProjectFile = createAsyncThunk(
+  'file/getProjectFile',
+  async (payload: { projectId: number; fileId: string }, thunkAPI) => {
+    try {
+      const response = await fileService.getProjectFile(payload.projectId, payload.fileId)
+      return response
+    } catch (error) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
+export const addProjectFile = createAsyncThunk(
+  'file/addProjectFile',
+  async (payload: { projectId: number; file: any }, thunkAPI) => {
+    try {
+      const response = await fileService.addProjectFile(payload.projectId, payload.file)
+      const files = await fileService.getProjectFiles(payload.projectId)
+      const formattedFiles = formatFiles(files)
+      if (response === 'File uploaded successfully') {
+        return {
+          message: response,
+          files: formattedFiles
+        }
+      }
+    } catch (error) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
+export const renameProjectFile = createAsyncThunk(
+  'file/renameProjectFile',
+  async (payload: { projectId: number; fileId: string; name: string }, thunkAPI) => {
+    try {
+      const response = await fileService.renameProjectFile(
+        payload.projectId,
+        payload.fileId,
+        payload.name
+      )
+      if (response === 'File updated successfully') {
+        const files = await fileService.getProjectFiles(payload.projectId)
+        const formattedFiles = formatFiles(files)
+        return formattedFiles
+      }
+    } catch (error) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
+export const deleteProjectFile = createAsyncThunk(
+  'file/deleteProjectFile',
+  async (payload: { projectId: number; fileId: string }, thunkAPI) => {
+    try {
+      const response = await fileService.deleteProjectFile(payload.projectId, payload.fileId)
+      if (response === 'File deleted successfully') {
+        const files = await fileService.getProjectFiles(payload.projectId)
+        const formattedFiles = formatFiles(files)
+        return formattedFiles
+      }
+    } catch (error) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
+export const fileSlice = createSlice({
+  name: 'projectFiles',
+  initialState,
+  reducers: {
+    resetFileState: (state) => {
+      state.isError = false
+      state.isLoading = false
+      state.isSuccess = false
+      state.error = {
+        status: 0,
+        content: null
+      }
+    }
+  },
+  extraReducers: (builder: ActionReducerMapBuilder<FileStateType>) => {
+    builder
+      .addCase(getProjectFiles.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(getProjectFiles.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isSuccess = true
+        state.isError = false
+        state.files = action.payload
+        state.error = {
+          status: 0,
+          content: null
+        }
+      })
+      .addCase(getProjectFiles.rejected, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isError = true
+        state.error = action.payload
+      })
+      .addCase(getProjectFile.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(getProjectFile.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isSuccess = true
+        state.files = action.payload
+      })
+      .addCase(getProjectFile.rejected, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isError = true
+        state.error = action.payload
+      })
+      .addCase(addProjectFile.pending, (state) => {
+        state.isLoading = true
+        state.isSuccess = false
+        state.isError = false
+      })
+      .addCase(addProjectFile.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isSuccess = true
+        state.files = action.payload.files
+      })
+      .addCase(addProjectFile.rejected, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isError = true
+        state.isSuccess = false
+        state.files = action.payload.files
+        state.error.status = action.payload.status
+        state.error.content = action.payload.content
+      })
+      .addCase(renameProjectFile.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(renameProjectFile.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isSuccess = true
+        state.files = action.payload
+      })
+      .addCase(renameProjectFile.rejected, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isError = true
+        state.error = action.payload
+      })
+      .addCase(deleteProjectFile.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(deleteProjectFile.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isSuccess = true
+        state.files = action.payload
+      })
+      .addCase(deleteProjectFile.rejected, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isError = true
+        state.error = action.payload
+      })
+  }
+})
+
+export const { resetFileState } = fileSlice.actions
+export default fileSlice.reducer

--- a/client/src/redux/files/fileType.ts
+++ b/client/src/redux/files/fileType.ts
@@ -1,0 +1,20 @@
+import { AxiosResponseError } from '~/shared/types'
+import { File } from '~/shared/interfaces'
+
+export type ProjectFileType = {
+  uuid: string
+  file_name: string
+  mime_type: string
+  size: number
+  created_at: string
+  updated_at: string
+  url: string
+}
+
+export type FileStateType = {
+  files: Array<File>
+  isError: boolean
+  isLoading: boolean
+  isSuccess: boolean
+  error: AxiosResponseError
+}

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -7,6 +7,7 @@ import sectionReducer from './section/sectionSlice'
 import settingReducer from './setting/settingSlice'
 import memberReducer from './member/memberSlice'
 import taskReducer from './task/taskSlice'
+import fileReducer from './files/fileSlice'
 
 export const store = configureStore({
   reducer: {
@@ -15,7 +16,8 @@ export const store = configureStore({
     setting: settingReducer,
     section: sectionReducer,
     member: memberReducer,
-    task: taskReducer
+    task: taskReducer,
+    file: fileReducer
   }
 })
 

--- a/client/src/shared/icons/BlankSlateTableIcon.tsx
+++ b/client/src/shared/icons/BlankSlateTableIcon.tsx
@@ -1,0 +1,20 @@
+import React from 'react'
+
+export const BlankSlateTableIcon: React.FC = (): JSX.Element => {
+  return (
+    <svg
+      aria-hidden="true"
+      height={24}
+      viewBox="0 0 24 24"
+      version="1.1"
+      width={24}
+      data-view-component="true"
+      className="octicon octicon-table blankslate-icon"
+    >
+      <path
+        fillRule="evenodd"
+        d="M2 3.75C2 2.784 2.784 2 3.75 2h16.5c.966 0 1.75.784 1.75 1.75v16.5A1.75 1.75 0 0120.25 22H3.75A1.75 1.75 0 012 20.25V3.75zM3.5 9v11.25c0 .138.112.25.25.25H7.5V9h-4zm4-1.5h-4V3.75a.25.25 0 01.25-.25H7.5v4zM9 9v11.5h11.25a.25.25 0 00.25-.25V9H9zm11.5-1.5H9v-4h11.25a.25.25 0 01.25.25V7.5z"
+      />
+    </svg>
+  )
+}

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -81,6 +81,7 @@ export interface File {
   size: string
   type: string
   date_upload: string
+  url: string
 }
 
 export type IconName = keyof typeof icons

--- a/client/src/shared/jsons/fileIconType.ts
+++ b/client/src/shared/jsons/fileIconType.ts
@@ -10,6 +10,10 @@ export const fileIconType: FileIcon[] = [
     Icon: Image
   },
   {
+    name: 'image/png',
+    Icon: Image
+  },
+  {
     name: 'application/pdf',
     Icon: PDFIcon
   },

--- a/client/src/shared/jsons/filesData.ts
+++ b/client/src/shared/jsons/filesData.ts
@@ -2,185 +2,211 @@ import { File } from './../interfaces'
 
 export const files: File[] = [
   {
-    id: '1',
-    filename: '1.webp',
-    size: '65.68kb',
-    type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    id: '8b3c9739-01c2-40f6-836a-b2654fabbee2',
+    filename: 'screenshot-1.png',
+    size: '139166b',
+    type: 'image/png',
+    date_upload: '2022-11-02T10:00:39.000000Z',
+    url: ''
   },
   {
     id: '2',
     filename: 'the quick brown fox jumps over the lazy dog near the bank of the river.',
     size: '23.01kb',
     type: 'image/webp',
-    date_upload: 'June 16, 2020'
+    date_upload: 'June 16, 2020',
+    url: ''
   },
   {
     id: '3',
     filename: '2.webp',
     size: '23.01 KB',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '4',
     filename: '3.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 16, 2020'
+    date_upload: 'June 16, 2020',
+    url: ''
   },
   {
     id: '5',
     filename: 'Resume-Joshua-Galit (2).pdf',
     size: '80.99 KB',
     type: 'application/pdf',
-    date_upload: 'October 27, 2022'
+    date_upload: 'October 27, 2022',
+    url: ''
   },
   {
     id: '6',
     filename: 'MARK PHILIP RESUME.docx',
     size: '64.01kb',
     type: 'application/vnd.openxmlformat',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '7',
     filename: '4. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '8',
     filename: '5. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '9',
     filename: '6. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '10',
     filename: '7. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '11',
     filename: '8. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '12',
     filename: '9.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '13',
     filename: '10.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '14',
     filename: '13. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '15',
     filename: '15. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '16',
     filename: '16. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '17',
     filename: '17. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '18',
     filename: '18. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '1000',
     filename: '1000.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '19',
     filename: '19.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '20',
     filename: '20. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '21',
     filename: '21. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '22',
     filename: '22. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '23',
     filename: '23. webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '24',
     filename: '24.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   },
   {
     id: '25',
     filename: '25.webp',
     size: '64.01kb',
     type: 'image/webp',
-    date_upload: 'June 30, 2020'
+    date_upload: 'June 30, 2020',
+    url: ''
   }
 ]

--- a/client/src/utils/formatFiles.ts
+++ b/client/src/utils/formatFiles.ts
@@ -1,0 +1,38 @@
+import moment from 'moment'
+
+import { File } from '~/shared/interfaces'
+import { ProjectFileType } from '~/redux/files/fileType'
+/*
+ * Match the schema of backend and frontend
+ *
+ */
+
+const formatFileSize = (size: number) => {
+  if (size < 1024) {
+    return `${size} B`
+  } else if (size < 1024 * 1024) {
+    return `${(size / 1024).toFixed(2)} KB`
+  } else if (size < 1024 * 1024 * 1024) {
+    return `${(size / 1024 / 1024).toFixed(2)} MB`
+  } else {
+    return `${(size / 1024 / 1024 / 1024).toFixed(2)} GB`
+  }
+}
+
+const formatFiles = (files: ProjectFileType[] | string): File[] | string => {
+  if (typeof files === 'string') {
+    return files
+  }
+  return files.map((file) => {
+    return {
+      id: file.uuid,
+      filename: file.file_name,
+      type: file.mime_type,
+      size: formatFileSize(file.size),
+      date_upload: moment(file.created_at).format('MMMM DD, YYYY'),
+      url: file.url
+    }
+  })
+}
+
+export default formatFiles


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203247946500427/f

## Definition of Done
- [x] A member of a project can see project-related files when clicking the `Files` tab.
- [x] A product owner of a project can upload project-related files when clicking the `Upload a file` button.
- [x] A team leader of a project can upload project-related files when clicking the `Upload a file` button. 
- [x] Added permissions.
- [x] Added Skeleton Table Loading.  
- [x] Fixed issue with loading. 

## Notes

## Pre-condition
cli: `cd api`
- php artisan migrate:fresh --seed

cli: `cd client`
- yarn dev || npm run dev
- go to `project/:id/files` to see project-related files and upload a file.

## Expected Output
- The page should display all existing project-related files.
- The user should be able to upload a file and the page should display the recently uploaded file by the user.

## Screenshots/Recordings

As a product owner


https://user-images.githubusercontent.com/109291819/199669705-313e2ce0-d49d-4cf5-8622-fe1adfdb1f07.mp4



As a team lead


https://user-images.githubusercontent.com/109291819/199669723-a9b80a7e-05b6-4fe9-baac-0b8532f7e0af.mp4



As a member


https://user-images.githubusercontent.com/109291819/199680282-cc917d7e-23ed-40d7-9988-3e2364caa867.mp4

Loading


[Slackana _ Overview (1).webm](https://user-images.githubusercontent.com/109291819/199690855-d3f72ead-7376-4edf-8337-63f99638c04f.webm)
