### PR TITLE
[440] - [FE] Integrate Mark as Read Notifications Functionality and Implement Redirect Notification

### DIFF
--- a/client/src/components/molecules/NotificationList/index.tsx
+++ b/client/src/components/molecules/NotificationList/index.tsx
@@ -1,9 +1,11 @@
 import moment from 'moment'
+import { NextRouter, useRouter } from 'next/router'
 import React, { FC } from 'react'
 import { GitHub } from 'react-feather'
 import { BsGithub } from 'react-icons/bs'
 import { FaRegUser } from 'react-icons/fa'
 
+import { useNotificationMethods } from '~/hooks/notificationMethods'
 import ImageSkeleton from '~/components/atoms/Skeletons/ImageSkeleton'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import { useAppSelector } from '~/hooks/reduxSelector'
@@ -15,6 +17,8 @@ type Props = {
 }
 
 const NotificationList: FC<Props> = (props): JSX.Element => {
+  const router: NextRouter = useRouter()
+  const { useMarkReadNotification } = useNotificationMethods()
   const { user } = useAppSelector((state) => state.auth)
   if (!props.notifications) null
 
@@ -60,6 +64,11 @@ const NotificationList: FC<Props> = (props): JSX.Element => {
     </tr>
   )
 
+  const handleReadNotification = (id: string, project_id: number, task_id: number) => {
+    useMarkReadNotification(id, project_id)
+    router.push(`/team/${project_id}/board?task_id=${task_id}`)
+  }
+
   return (
     <table className="min-w-2xl w-full flex-1 divide-y divide-slate-300 overflow-auto border-t border-slate-300 text-left text-sm leading-normal">
       <tbody className="w-full divide-y divide-slate-300 text-sm text-slate-600">
@@ -93,8 +102,14 @@ const NotificationList: FC<Props> = (props): JSX.Element => {
                       )}
                     </span>
                     <a
-                      href={`/team/${notification.data.project_id}/board?task_id=${notification.data.task?.id}`}
-                      className="font-semibold text-slate-900 underline line-clamp-1"
+                      onClick={() =>
+                        handleReadNotification(
+                          notification.id,
+                          notification.data.project_id,
+                          notification.data.task?.id as number
+                        )
+                      }
+                      className="cursor-pointer font-semibold text-slate-900 underline line-clamp-1"
                     >
                       {notification.data.task?.name}
                     </a>

--- a/client/src/shared/interfaces/index.ts
+++ b/client/src/shared/interfaces/index.ts
@@ -97,7 +97,7 @@ export interface SidebarProject {
 }
 
 export interface Notification {
-  id: number
+  id: string
   data: {
     type: string
     task?: {


### PR DESCRIPTION
## Backend
- https://github.com/abduljalilpalala/ps-slackana/pull/138
## Asana Link
- https://app.asana.com/0/1203011167276287/1203247946500440/f

## Definition of Done
- [x] User can mark a notification as read by clicking on the task
- [x] User can be redirected to the task itself by clicking the on the task notification


## Notes
- None

## Pre-condition
- Login on the app
- Click the notification bell
- Click on see all notifications
- Click the task notification
- Then go back to the the notification page

## Expected Output
- Should be able to mark a notification as read by clicking the task and then be redirected on the task itself

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/199704521-c4f82b8f-1dad-4705-8151-1b7a8f72ebfc.mp4


