### PR TITLE
[551] - [BugTask] When uploading a document file with an existing filename, there is no suffix number in the document files

### DIFF
--- a/api/app/Http/Resources/ProjectFileResource.php
+++ b/api/app/Http/Resources/ProjectFileResource.php
@@ -16,6 +16,8 @@ class ProjectFileResource extends JsonResource
     {
         return [
             'uuid' => $this->uuid,
+            'name' => $this->name,
+            'extension' => $this->extension,
             'file_name' => $this->file_name,
             'mime_type' => $this->mime_type,
             'size' => $this->size,

--- a/api/app/Utils/ProjectFileUtils.php
+++ b/api/app/Utils/ProjectFileUtils.php
@@ -9,11 +9,13 @@ namespace App\Utils;
 
 class ProjectFileUtils
 {
-  public function addSuffixToFileName($file_name, $mediaItems)
+  public function addSuffixToName($name, $project)
   {
-    $file_name_parts = explode('.', $file_name);
-    $file_name = $file_name_parts[0] . ' (' . $mediaItems->count() . ')' . '.' . $file_name_parts[1];
-
-    return $file_name;
+    $mediaItems = $project->getMedia('project-files');
+    $count = $mediaItems->filter(function ($item) use ($name) {
+      return !strpos($item->name, $name);
+    })->count();
+    $name = $name . ' (' . $count . ')';
+    return $name;
   }
 }

--- a/client/src/components/molecules/FileList/EditFilenameDialog.tsx
+++ b/client/src/components/molecules/FileList/EditFilenameDialog.tsx
@@ -51,10 +51,15 @@ const EditFilenameDialog: FC<Props> = (props): JSX.Element => {
       return filename === data.filename && file.id !== data.id
     })
 
+    const matchCount = files.filter((file) => {
+      const filename = file.filename.split('.')[0]
+      return filename.startsWith(data.filename) && file.id !== data.id
+    }).length
+
     if (duplicateFiles.length > 0) {
       EditFilenameModal(
-        'The file has duplicates, do you want to continue?',
-        '',
+        'The file has duplicates',
+        `The file ${filename} will be renamed to ${filename} (${matchCount}). Would you like to continue?`,
         async (confirmed: boolean) => {
           if (confirmed) {
             // Look for all files that starts with the file name
@@ -62,7 +67,7 @@ const EditFilenameDialog: FC<Props> = (props): JSX.Element => {
               const filename = file.filename.split('.')[0]
               return filename.startsWith(data.filename) && file.id !== data.id
             })
-            const newFileName = `${filename}-(${fileMatches.length})`
+            const newFileName = `${filename} (${fileMatches.length})`
             await handleUpdateFilename({ id: data.id, filename: newFileName })
             closeModal({ id: data.id, filename: newFileName })
           }

--- a/client/src/redux/files/fileType.ts
+++ b/client/src/redux/files/fileType.ts
@@ -4,6 +4,8 @@ import { File } from '~/shared/interfaces'
 export type ProjectFileType = {
   uuid: string
   file_name: string
+  name: string
+  extension: string
   mime_type: string
   size: number
   created_at: string

--- a/client/src/utils/formatFiles.ts
+++ b/client/src/utils/formatFiles.ts
@@ -26,7 +26,7 @@ const formatFiles = (files: ProjectFileType[] | string): File[] | string => {
   return files.map((file) => {
     return {
       id: file.uuid,
-      filename: file.file_name,
+      filename: file.name + '.' + file.extension,
       type: file.mime_type,
       size: formatFileSize(file.size),
       date_upload: moment(file.created_at).format('MMMM DD, YYYY'),


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203299557301551/f

## Definition of Done
- Fixed problems with renaming files.

## Notes
- Made changes to store and update of `ProjectFileController`, reconciling the differences between `file_name` and `name`.

## Pre-condition
- Please remove the existing files before testing.

## Expected Output
- When renaming, the file with existing filename must have a suffix added to it when allowed by the user.
-  
https://user-images.githubusercontent.com/109291819/199972820-b78a1675-5b44-45ae-9923-a6813977a0d9.mp4

