### PR TITLE
[638] - [BugTask] In another account, the name displayed is incorrect when sending a message and no 3 Dots icon is displayed

### DIFF
--- a/api/app/Http/Controllers/ProjectMessageController.php
+++ b/api/app/Http/Controllers/ProjectMessageController.php
@@ -23,7 +23,7 @@ class ProjectMessageController extends Controller
   public function store(ProjectMessageRequest $request, Project $project)
   {
     $project->messages()->create([
-      'project_member_id' => $request->member_id,
+      'project_member_id' => $project->user($request->member_id)->firstOrFail()->id,
       'message' => $request->message
     ]);
     return $this->returnData($project);

--- a/api/app/Http/Controllers/ProjectMessageThreadController.php
+++ b/api/app/Http/Controllers/ProjectMessageThreadController.php
@@ -5,6 +5,7 @@ namespace App\Http\Controllers;
 use App\Events\SendProjectMessageThreadEvent;
 use App\Http\Requests\ProjectMessageRequest;
 use App\Http\Resources\ProjectMessageResource;
+use App\Models\Project;
 use App\Models\ProjectMessage;
 use App\Models\ProjectMessageThread;
 
@@ -18,7 +19,7 @@ class ProjectMessageThreadController extends Controller
   public function store(ProjectMessageRequest $request, ProjectMessage $message)
   {
     $message->thread()->create([
-      'project_member_id' => $request->member_id,
+      'project_member_id' => Project::find($request->project_id)->user($request->member_id)->firstOrFail()->id,
       'message' => $request->message
     ]);
 

--- a/api/app/Http/Requests/ProjectMessageRequest.php
+++ b/api/app/Http/Requests/ProjectMessageRequest.php
@@ -24,6 +24,7 @@ class ProjectMessageRequest extends FormRequest
   public function rules()
   {
     return [
+      'project_id' => ['nullable'],
       'member_id' => ['required'],
       'message' => ['required']
     ];

--- a/api/app/Models/Project.php
+++ b/api/app/Models/Project.php
@@ -72,4 +72,9 @@ class Project extends Model implements HasMedia
         ->preservingOriginal()->toMediaCollection('project-icon', 'public');
     });
   }
+
+  public function user(int $userId)
+  {
+    return $this->members()->where('user_id', $userId);
+  }
 }

--- a/api/database/seeders/ProjectSeeder.php
+++ b/api/database/seeders/ProjectSeeder.php
@@ -45,7 +45,7 @@ class ProjectSeeder extends Seeder
       $project = Project::updateOrCreate([
         'title' => 'Slackana'
       ], [
-        'titles' => 'Slackana',
+        'title' => 'Slackana',
         'description' => 'Lorem ipsum dolor sit amet, consectetur adipisicing elit. Magnam neque, ut dicta voluptate mollitia quo nam, perspiciatis aspernatur, sint nihil facilis ab quas molestiae culpa officiis quis aliquam quidem commodi!',
         'status_id' => ProjectStatusEnum::ON_TRACK,
       ]);

--- a/client/src/pages/team/[id]/chat.tsx
+++ b/client/src/pages/team/[id]/chat.tsx
@@ -137,6 +137,7 @@ const Chat: NextPage = (): JSX.Element => {
     const request = {
       messageId: chat_id,
       payload: {
+        project_id: id,
         member_id: user?.id,
         message: data?.message
       }

--- a/client/src/redux/chat/chatSlice.ts
+++ b/client/src/redux/chat/chatSlice.ts
@@ -158,10 +158,8 @@ export const chatSlice = createSlice({
       })
 
       state.chats = newMessages
-
-      if (state.message) {
-        state.message.thread = newThreadMessages
-      }
+      state.threads = newThreadMessages
+      state.message!.thread = newThreadMessages
     }
   },
   extraReducers: (builder: ActionReducerMapBuilder<InitialState>) => {
@@ -265,8 +263,14 @@ export const chatSlice = createSlice({
           status: 0,
           content: null
         }
+        const { message, newThreadMessages } = payload || {}
+        const newMessages = current(state.chats).map((chat) => {
+          if (chat.id === message.id) return message
+          return chat
+        })
 
-        setThreads(payload)
+        state.chats = newMessages
+        if (state.message) state.message.thread = newThreadMessages
       })
       .addCase(addThread.rejected, (state, action: PayloadAction<any>) => {
         state.isLoading = false
@@ -280,7 +284,14 @@ export const chatSlice = createSlice({
       .addCase(deleteThread.fulfilled, (state, { payload }: PayloadAction<any>) => {
         state.isLoading = false
         state.isSuccess = true
-        setThreads(payload)
+        const { message, newThreadMessages } = payload || {}
+        const newMessages = current(state.chats).map((chat) => {
+          if (chat.id === message.id) return message
+          return chat
+        })
+
+        state.chats = newMessages
+        if (state.message) state.message.thread = newThreadMessages
       })
       .addCase(deleteThread.rejected, (state, action: PayloadAction<any>) => {
         state.isLoading = false


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203308773766638/f

## Definition of Done
- [x] Fixed name displayed when a member of the project has send a message
- [x] Options Icon (3 dots) now displays when the member hovers on to its message in the chat

## Notes
- Realtime data might not be working due to Pusher's limited connections for an account
- Fixed thread messaging not working previously

## Pre-condition
- Send a message in the project's chat section

## Expected Output
- The Sender will expect it's name to be displayed when he/she has send the message and will also be able to display the Options Icon (3 dots) when hovered on the message sent.

## Screenshots/Recordings
- Demo

[screen-recording (8).webm](https://user-images.githubusercontent.com/108660012/200233844-0f0e57b8-2373-4fec-85e6-7905503c177a.webm)
