### PR TITLE
[760] - [BugTask] When clicking on the thread icon in mobile view, the thread component will slide from the right side of the screen

### DIFF
--- a/client/src/components/molecules/ChatList/index.tsx
+++ b/client/src/components/molecules/ChatList/index.tsx
@@ -171,7 +171,7 @@ const ChatList: FC<Props> = (props): JSX.Element => {
                       onClick={() => router.push(`/team/${id}/chat/?chat_id=${chat.id}`)}
                       data-for="actions"
                       data-tip="Reply to thread"
-                      className="rounded p-1 text-slate-400 focus:bg-slate-200 focus:text-slate-900 hover:bg-slate-200 hover:text-slate-900"
+                      className="mb-0.5 rounded p-1 text-slate-400 focus:bg-slate-200 focus:text-slate-900 hover:bg-slate-200 hover:text-slate-900"
                     >
                       <ThreadMessageIcon className="h-5 w-5 fill-current" />
                     </button>

--- a/client/src/components/molecules/MessageOptionDropdown/index.tsx
+++ b/client/src/components/molecules/MessageOptionDropdown/index.tsx
@@ -22,7 +22,7 @@ const MessageOptionDropdown: FC<Props> = (props): JSX.Element => {
       <Menu.Button
         data-for="act"
         data-tip="More Actions"
-        className="rounded p-1 text-slate-400 focus:bg-slate-200 focus:text-slate-900 hover:bg-slate-200 hover:text-slate-900"
+        className="rounded p-1 text-slate-400 outline-none focus:bg-slate-200 focus:text-slate-900 hover:bg-slate-200 hover:text-slate-900"
       >
         <MoreVertical className="h-5 w-5" />
         <ReactTooltip

--- a/client/src/components/molecules/ThreadList/index.tsx
+++ b/client/src/components/molecules/ThreadList/index.tsx
@@ -148,27 +148,28 @@ const ThreadList: FC<Props> = (props): JSX.Element => {
                         </article>
                       </section>
                     </main>
-                    <aside
-                      className={`
+                    {author?.id === user?.id && (
+                      <aside
+                        className={`
                         absolute right-4 -top-4 flex items-center justify-center space-x-0.5 rounded border
                         border-slate-300 bg-white px-0.5 pt-0.5 opacity-0 shadow-lg group-message-hover:opacity-100
                       `}
-                    >
-                      {author?.id === user?.id && (
+                      >
                         <ThreadOptionDropdown
                           thread={thread}
                           actions={{ handleDeleteThread, handleOpenEditThreadDialog }}
                         />
-                      )}
-                      <ReactTooltip
-                        place="top"
-                        type="dark"
-                        effect="solid"
-                        id="actions"
-                        getContent={(dataTip) => dataTip}
-                        className="!rounded-lg !bg-black !text-xs font-semibold !text-white"
-                      />
-                    </aside>
+
+                        <ReactTooltip
+                          place="top"
+                          type="dark"
+                          effect="solid"
+                          id="actions"
+                          getContent={(dataTip) => dataTip}
+                          className="!rounded-lg !bg-black !text-xs font-semibold !text-white"
+                        />
+                      </aside>
+                    )}
                   </section>
                 )
               })}

--- a/client/src/components/organisms/ProjectHeader/index.tsx
+++ b/client/src/components/organisms/ProjectHeader/index.tsx
@@ -143,7 +143,7 @@ const ProjectHead: FC = (): JSX.Element => {
     <div className="flex w-full items-center">
       {addRepo && addRepoComponent}
       {addModal && <AddMemberModal close={() => setAddModal(false)} />}
-      <header css={styles.header} className="w-full min-w-[360px]">
+      <header css={styles.header} className="w-full min-w-[366px]">
         <section css={styles.section}>
           {isLoading ? (
             !hotReload ? (
@@ -229,23 +229,25 @@ const ProjectHead: FC = (): JSX.Element => {
           <h3 className="group-hover:text-slate-800">{members && numberOfActiveMembers}</h3>
         </button>
       </header>
-      {router.query.chat_id && (
-        <header className="flex w-[350px] flex-shrink-0 items-center justify-between border-b border-l border-slate-300 py-3 px-4 text-slate-600">
-          <div className="flex items-center space-x-1">
-            <h1 className="py-0.5 text-lg font-bold text-slate-900">Thread</h1>
-            <p className="flex items-center text-sm text-slate-500">
-              <Hash className="ml-2 h-4 w-4" />
-              {projectTitle}
-            </p>
-          </div>
-          <button
-            className="rounded p-0.5 hover:bg-slate-200 active:scale-95"
-            onClick={() => router.push(`/team/${id}/chat`)}
-          >
-            <X className="h-5 w-5" />
-          </button>
-        </header>
-      )}
+      <div className="hidden lg:block">
+        {router.query.chat_id && (
+          <header className="flex w-[351px] flex-shrink-0 items-center justify-between border-b border-l border-slate-300 py-3 px-4 text-slate-600">
+            <div className="flex items-center space-x-1">
+              <h1 className="py-0.5 text-lg font-bold text-slate-900">Thread</h1>
+              <p className="flex items-center text-sm text-slate-500">
+                <Hash className="ml-2 h-4 w-4" />
+                {projectTitle}
+              </p>
+            </div>
+            <button
+              className="rounded p-0.5 hover:bg-slate-200 active:scale-95"
+              onClick={() => router.push(`/team/${id}/chat`)}
+            >
+              <X className="h-5 w-5" />
+            </button>
+          </header>
+        )}
+      </div>
     </div>
   )
 }

--- a/client/src/components/organisms/ThreadDrawer/index.tsx
+++ b/client/src/components/organisms/ThreadDrawer/index.tsx
@@ -1,0 +1,264 @@
+import moment from 'moment'
+import { Hash, X } from 'react-feather'
+import { useRouter } from 'next/router'
+import ReactTooltip from 'react-tooltip'
+import ReactMarkdown from 'react-markdown'
+import { UseFormReset } from 'react-hook-form'
+import React, { FC, useEffect, useState } from 'react'
+
+import { Chat } from '~/redux/chat/chatType'
+import { ChatMessageValues } from '~/shared/types'
+import { ThreadMessage } from '~/shared/interfaces'
+import { Spinner } from '~/shared/icons/SpinnerIcon'
+import { showMessage } from '~/redux/chat/chatSlice'
+import handleImageError from '~/helpers/handleImageError'
+import ChatEditor from '~/components/molecules/ChatEditor'
+import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
+import ThreadOptionDropdown from '~/components/molecules/ThreadOptionDropdown'
+import EditMessageDialog from '~/components/molecules/ThreadList/EditMessageDialog'
+
+type Props = {
+  isLoadingThread: boolean
+  chatData: Chat[]
+  threads: Chat[]
+  isOpenEditModalThread: boolean
+  isLoadingSubmitThreadChat: boolean
+  actions: {
+    handleDeleteThread: (payload: {
+      messageId: string | string[] | undefined
+      threadId: number
+    }) => Promise<void>
+    handleUpdateThread: (data: ThreadMessage) => Promise<void>
+    handleCloseEditModalThreadToggle: () => void
+    handleReplyThread: (data: ChatMessageValues) => Promise<void>
+    onPressAddThread: (
+      event: React.KeyboardEvent<HTMLFormElement>,
+      data: ChatMessageValues,
+      reset: UseFormReset<ChatMessageValues>
+    ) => void
+  }
+}
+
+const ThreadSlider: FC<Props> = (props): JSX.Element => {
+  const {
+    isLoadingThread,
+    isOpenEditModalThread,
+    threads,
+    isLoadingSubmitThreadChat,
+    actions: {
+      handleDeleteThread,
+      handleUpdateThread,
+      handleCloseEditModalThreadToggle,
+      handleReplyThread,
+      onPressAddThread
+    }
+  } = props
+
+  const {
+    overviewProject: { title }
+  } = useAppSelector((state) => state.project)
+
+  const { message } = useAppSelector((state) => state.chat)
+  const [threadMessage, setThreadMessage] = useState<ThreadMessage>({
+    id: 0,
+    thread_id: 0,
+    message: ''
+  })
+
+  const router = useRouter()
+  const { id, chat_id } = router.query
+  const dispatch = useAppDispatch()
+  const { user: author } = useAppSelector((state) => state.auth)
+
+  useEffect(() => {
+    if (chat_id) {
+      onLoadThread()
+    }
+  }, [chat_id])
+
+  const onLoadThread = async () => {
+    if (id && chat_id) {
+      const payload = {
+        projectId: id,
+        messageId: chat_id
+      }
+      await dispatch(showMessage(payload))
+    }
+  }
+
+  const handleOpenEditThreadDialog = (thread?: Chat) => {
+    const data = {
+      thread_id: thread?.id,
+      message: thread?.message
+    }
+    setThreadMessage(data)
+    handleCloseEditModalThreadToggle()
+  }
+
+  return (
+    <>
+      {chat_id && (
+        <section
+          className="absolute inset-0 z-10 block bg-slate-900/10 lg:hidden"
+          onClick={() => router.push(`/team/${router.query.id}/chat`)}
+        ></section>
+      )}
+      <section
+        className={`
+          fixed right-0 z-20 h-full w-full flex-1 flex-shrink-0 overflow-hidden
+           bg-white text-slate-900 transition-all duration-300 ease-in-out sm:max-w-[351px] 
+          ${chat_id ? 'block translate-x-0 lg:hidden' : 'translate-x-full'}
+        `}
+      >
+        <header className="flex w-full flex-shrink-0 items-center justify-between border-b border-slate-300 py-3 px-4 text-slate-600">
+          <div className="flex items-center space-x-1">
+            <h1 className="py-0.5 text-lg font-bold text-slate-900">Thread</h1>
+            <p className="flex items-center text-sm text-slate-500">
+              <Hash className="ml-2 h-4 w-4" />
+              {title}
+            </p>
+          </div>
+          <button
+            className="rounded p-0.5 hover:bg-slate-200 active:scale-95"
+            onClick={() => router.push(`/team/${id}/chat`)}
+          >
+            <X className="h-5 w-5" />
+          </button>
+        </header>
+        <main className="default-scrollbar flex h-full flex-col overflow-y-auto">
+          {isOpenEditModalThread && (
+            <EditMessageDialog
+              isOpen={isOpenEditModalThread}
+              threadMessage={threadMessage}
+              closeModal={handleCloseEditModalThreadToggle}
+              actions={{ handleUpdateThread }}
+            />
+          )}
+          {isLoadingThread ? (
+            <div className="flex items-center justify-center py-6">
+              <Spinner className="h-5 w-5 text-blue-500" />
+            </div>
+          ) : (
+            <>
+              <section
+                key={message?.id}
+                className="mt-2 flex items-start space-x-2 px-4 py-2 transition duration-75 ease-in-out"
+              >
+                <header className="flex-shrink-0">
+                  <img
+                    src={message?.member?.user?.avatar?.url}
+                    onError={(e) => handleImageError(e, '/images/avatar.png')}
+                    className="h-8 w-8 rounded-md"
+                    alt=""
+                  />
+                </header>
+                <main className="text-sm text-slate-900">
+                  <header className="flex items-end space-x-2">
+                    <h3 className="font-bold line-clamp-1">{message?.member?.user?.name}</h3>
+                    <p className="text-xs text-slate-500 line-clamp-1">
+                      {moment(message?.created_at).fromNow()}
+                    </p>
+                  </header>
+                  <section>
+                    <article className="prose pb-6">
+                      <ReactMarkdown children={`${message?.message}`} />
+                    </article>
+                  </section>
+                </main>
+              </section>
+              <Divider threadCount={message?.thread?.length} />
+              {!message?.thread?.length ? (
+                <p className="text-center text-sm font-normal text-slate-400">No Threads</p>
+              ) : (
+                <>
+                  {message?.thread?.map((thread) => {
+                    const user = thread?.member?.user
+                    return (
+                      <section
+                        key={thread.id}
+                        className="group-message relative flex items-start space-x-2 px-6 py-2 transition duration-75 ease-in-out hover:bg-slate-100"
+                      >
+                        <header className="flex-shrink-0">
+                          <img
+                            src={user?.avatar.url}
+                            onError={(e) => handleImageError(e, '/images/avatar.png')}
+                            className="h-8 w-8 rounded-md"
+                            alt=""
+                          />
+                        </header>
+                        <main className="text-sm text-slate-900">
+                          <header className="flex items-end space-x-2">
+                            <h3 className="font-bold line-clamp-1">{user?.name}</h3>
+                            <p className="text-xs text-slate-500 line-clamp-1">
+                              {moment(thread.created_at).fromNow()}
+                            </p>
+                          </header>
+                          <section>
+                            <article className="prose pb-6">
+                              <ReactMarkdown children={thread.message} />
+                            </article>
+                          </section>
+                        </main>
+                        {author?.id === user?.id && (
+                          <aside
+                            className={`
+                            absolute right-4 -top-4 flex items-center justify-center space-x-0.5 rounded border
+                            border-slate-300 bg-white px-0.5 pt-0.5 opacity-0 shadow-lg group-message-hover:opacity-100
+                          `}
+                          >
+                            <ThreadOptionDropdown
+                              thread={thread}
+                              actions={{ handleDeleteThread, handleOpenEditThreadDialog }}
+                            />
+
+                            <ReactTooltip
+                              place="top"
+                              type="dark"
+                              effect="solid"
+                              id="actions"
+                              getContent={(dataTip) => dataTip}
+                              className="!rounded-lg !bg-black !text-xs font-semibold !text-white"
+                            />
+                          </aside>
+                        )}
+                      </section>
+                    )
+                  })}
+                </>
+              )}
+            </>
+          )}
+          <div className="px-4 py-2 pb-[90px]">
+            <ChatEditor
+              handleMessage={handleReplyThread}
+              checkKeyDown={onPressAddThread}
+              isLoadingEnterPress={isLoadingSubmitThreadChat}
+            />
+          </div>
+        </main>
+      </section>
+    </>
+  )
+}
+
+type DividerProps = {
+  threadCount: number | undefined
+}
+
+const Divider = ({ threadCount }: DividerProps) => {
+  return (
+    <>
+      {!!threadCount && (
+        <div className="px-6 py-3">
+          <div className="relative flex items-center border-b border-slate-200">
+            <span className="absolute bg-white pr-2 text-xs font-medium text-slate-500">
+              {`${threadCount} ${threadCount === 1 ? 'reply' : 'replies'}`}
+            </span>
+          </div>
+        </div>
+      )}
+    </>
+  )
+}
+
+export default ThreadSlider

--- a/client/src/pages/team/[id]/chat.tsx
+++ b/client/src/pages/team/[id]/chat.tsx
@@ -25,6 +25,7 @@ import {
   setThreads
 } from '~/redux/chat/chatSlice'
 import { pusher } from '~/shared/lib/pusher'
+import ThreadSlider from '~/components/organisms/ThreadDrawer'
 
 const Chat: NextPage = (): JSX.Element => {
   const router = useRouter()
@@ -286,35 +287,54 @@ const Chat: NextPage = (): JSX.Element => {
             />
           </div>
         </section>
-        {chat_id && (
-          <section
-            className={`
-            default-scrollbar flex h-screen w-[350px] flex-shrink-0 flex-col 
-            overflow-y-auto scrollbar-thumb-slate-400`}
-          >
-            <ThreadList
-              chatData={chats}
-              threads={threads}
-              isLoadingThread={isLoadingThread}
-              isOpenEditModalThread={isOpenEditModalThread}
-              actions={{
-                handleDeleteThread,
-                handleUpdateThread,
-                handleCloseEditModalThreadToggle
-              }}
-            />
-            {!isLoadingThread && (
-              <div className="px-4 py-2">
-                <ChatEditor
-                  handleMessage={handleReplyThread}
-                  checkKeyDown={onPressAddThread}
-                  isLoadingEnterPress={isLoadingSubmitThreadChat}
-                />
-              </div>
-            )}
-          </section>
-        )}
+        <div className="hidden lg:block">
+          {chat_id && (
+            <section
+              className={`
+                default-scrollbar flex h-screen w-[350px] flex-shrink-0 flex-col 
+                overflow-y-auto scrollbar-thumb-slate-400
+              `}
+            >
+              <ThreadList
+                chatData={chats}
+                threads={threads}
+                isLoadingThread={isLoadingThread}
+                isOpenEditModalThread={isOpenEditModalThread}
+                actions={{
+                  handleDeleteThread,
+                  handleUpdateThread,
+                  handleCloseEditModalThreadToggle
+                }}
+              />
+              {!isLoadingThread && (
+                <div className="px-4 py-2">
+                  <ChatEditor
+                    handleMessage={handleReplyThread}
+                    checkKeyDown={onPressAddThread}
+                    isLoadingEnterPress={isLoadingSubmitThreadChat}
+                  />
+                </div>
+              )}
+            </section>
+          )}
+        </div>
       </div>
+
+      {/* This will show the thread list on mobile view */}
+      <ThreadSlider
+        chatData={chats}
+        threads={threads}
+        isLoadingThread={isLoadingThread}
+        isOpenEditModalThread={isOpenEditModalThread}
+        isLoadingSubmitThreadChat={isLoadingSubmitThreadChat}
+        actions={{
+          handleDeleteThread,
+          handleUpdateThread,
+          handleCloseEditModalThreadToggle,
+          handleReplyThread,
+          onPressAddThread
+        }}
+      />
     </ProjectLayout>
   )
 }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203333496313760/f

## Definition of Done
- [x] Created `ThreadDrawer` component for mobile thread list design
- [x] Reused components and ensures CRUD operation works perfectly fine

## Notes
- None

## Pre-condition
- yarn dev || npm run start
- Go to the chat page `/teams/${id}/chat` and click the thread and resize it into the mobile and it will eventually popup the thread drawer

## Expected Output
- It should have a thread drawer pop when resizing into mobile view

## Screenshots/Recordings
![threadlist](https://user-images.githubusercontent.com/108642414/200820991-d3cc28e1-c97f-4fb1-b504-7a73949ad232.gif)

