### PR TITLE
[080] - [BE] Implement Mute Notifications when Project is archived Functionality

### DIFF
--- a/api/app/Http/Controllers/NudgeMemberController.php
+++ b/api/app/Http/Controllers/NudgeMemberController.php
@@ -10,7 +10,9 @@ class NudgeMemberController extends Controller
 {
   public function show(Project $project, User $member)
   {
-    event(new NudgeMemberEvent($project, $member));
+    if (!$project->is_archived) {
+      event(new NudgeMemberEvent($project, $member));
+    }
     
     return response()->noContent();
   }

--- a/api/app/Http/Controllers/ProjectMessageController.php
+++ b/api/app/Http/Controllers/ProjectMessageController.php
@@ -12,7 +12,7 @@ class ProjectMessageController extends Controller
 {
   public function index(Project $project)
   {
-    return ProjectMessageResource::collection($project->messages()->withCount(['thread'])->with(['member.user.avatar', 'thread.member.user.avatar'])->get());
+    return ProjectMessageResource::collection($project->messages()->withCount(['thread'])->with(['member.user.avatar', 'thread.member.user.avatar'])->orderBy('created_at', 'asc')->get());
   }
 
   public function show(Project $project, ProjectMessage $message)

--- a/api/app/Http/Controllers/TaskAssignmentController.php
+++ b/api/app/Http/Controllers/TaskAssignmentController.php
@@ -24,7 +24,9 @@ class TaskAssignmentController extends Controller
       $member = ProjectMember::with('user')->findOrFail($request->project_member_id);
       if (intval($taskMemberID) !== intval($request->project_member_id)) {
         Notification::send($member->user, new AssignTaskNotification(auth()->user()->id, $task->id, $project->id));
-        event(new AssignTaskEvent($member->user, $project));
+        if (!$project->is_archived) {
+          event(new AssignTaskEvent($member->user, $project));
+        }
       }
       return response()->noContent();
     }

--- a/api/app/Http/Controllers/TaskController.php
+++ b/api/app/Http/Controllers/TaskController.php
@@ -43,7 +43,9 @@ class TaskController extends Controller
       if ($request->project_member_id) {
         $member = ProjectMember::with('user')->findOrFail($request->project_member_id);
         Notification::send($member->user, new AssignTaskNotification(auth()->user()->id, $task->id, $project->id));
-        event(new AssignTaskEvent($member->user, $project));
+        if (!$project->is_archived) {
+          event(new AssignTaskEvent($member->user, $project));
+        }
       }
       return response()->noContent();
     }

--- a/api/app/Jobs/HandleMergeWebhookJob.php
+++ b/api/app/Jobs/HandleMergeWebhookJob.php
@@ -49,8 +49,10 @@ class HandleMergeWebhookJob implements ShouldQueue
           'message' => json_encode($message)
         ]);
         Notification::send($users, new GithubMergeNotification($payload->pull_request->merged_by, $pr_details, $project->id));
-        event(new GithubWebhookEvent($users, $project));
-        event(new SendProjectMessageEvent($project));
+        if (!$project->is_archived) {
+          event(new GithubWebhookEvent($users, $project));
+          event(new SendProjectMessageEvent($project));
+        }
       }
     }
   }

--- a/api/app/Jobs/HandlePushWebhookJob.php
+++ b/api/app/Jobs/HandlePushWebhookJob.php
@@ -46,8 +46,10 @@ class HandlePushWebhookJob implements ShouldQueue
           'message' => json_encode($message)
         ]);
         Notification::send($users, new GithubPushNotification($payload->sender, $payload->repository, $commit, $project->id));
-        event(new GithubWebhookEvent($users, $project));
-        event(new SendProjectMessageEvent($project));
+        if (!$project->is_archived) {
+          event(new GithubWebhookEvent($users, $project));
+          event(new SendProjectMessageEvent($project));
+        }
       }
     }
   }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203326954304080/f

## Definition of Done
- [x] Project Leader, Project Owner and Member will no longer receive nudge and notifications whenever the project is archived

## Notes
- None

## Pre-condition
- Archive a Project
- Perform a notification event such as Task Assignment or Nudging a Member

## Expected Output
- The user on the other end will not receive notifications when the project is archived

## Screenshots/Recordings

https://user-images.githubusercontent.com/108660012/201000828-eead63e7-0789-4c9e-b907-1fd8a0a7c95f.mp4


