### PR TITLE
[764] - [FE] If greater than 2MB or more than 20 files, inform the user that it is limited up to 20 files only and the size of each file must not be greater than 2MB

### DIFF
--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -51,6 +51,13 @@ Route::group(['middleware' => 'auth:sanctum'], function () {
   Route::apiResource('notification', NotificationController::class);
   Route::apiResource('project.message', ProjectMessageController::class);
 
+  Route::group(['prefix' => 'ini'], function () {
+    Route::get('/', function () {
+      return ['upload_max_filesize' => ini_get('upload_max_filesize'), 'max_file_uploads' => ini_get('max_file_uploads')];
+    });
+  });
+
+
   Route::group(['prefix' => 'project'], function () {
     Route::put('/{project}/change-settings', [ProjectSettingController::class, 'update']);
     Route::put('/{project}/repository', [ProjectRepositoryController::class, 'update']);

--- a/client/src/redux/files/fileService.ts
+++ b/client/src/redux/files/fileService.ts
@@ -1,8 +1,14 @@
 import { axios } from '~/shared/lib/axios'
 import { ProjectFileType } from '~/redux/files/fileType'
+import { IniValueType } from '~/shared/types'
 
 const getProjectFiles = async (projectId: number): Promise<Array<ProjectFileType> | string> => {
   const response = await axios.get(`/api/project/${projectId}/file`)
+  return response.data
+}
+
+const getIniValue = async (): Promise<IniValueType> => {
+  const response = await axios.get('/api/ini/')
   return response.data
 }
 
@@ -45,7 +51,8 @@ const fileService = {
   getProjectFile,
   addProjectFile,
   renameProjectFile,
-  deleteProjectFile
+  deleteProjectFile,
+  getIniValue
 }
 
 export default fileService

--- a/client/src/shared/types/index.ts
+++ b/client/src/shared/types/index.ts
@@ -1,6 +1,11 @@
 import { IconType } from 'react-icons'
 import { Icon } from 'react-feather'
 
+export type IniValueType = {
+  upload_max_filesize: string
+  max_file_uploads: string
+}
+
 export type SignInUpFormValues = {
   name: string
   email: string

--- a/client/src/utils/formatIniValues.ts
+++ b/client/src/utils/formatIniValues.ts
@@ -1,0 +1,28 @@
+import { IniValueType } from '~/shared/types'
+
+type FormatIniValuesType = {
+  max_file_size: number
+  max_file_uploads: number
+}
+
+export const formatIniValues = (iniValues: IniValueType): FormatIniValuesType => {
+  // extract the letter from the string max_file_size
+  const max_file_size_letter = iniValues.upload_max_filesize.slice(-1)
+  // extract the number from the string max_file_size
+  const max_file_size_number = parseInt(iniValues.upload_max_filesize.slice(0, -1))
+  let max_file_size = 0
+  // convert the number to bytes
+  if (max_file_size_letter === 'M') {
+    max_file_size = max_file_size_number * 1024 * 1024
+  } else if (max_file_size_letter === 'K') {
+    max_file_size = max_file_size_number * 1024
+  } else if (max_file_size_letter === 'G') {
+    max_file_size = max_file_size_number * 1024 * 1024 * 1024
+  }
+  // extract the number from the string max_file_uploads
+  const max_file_uploads = parseInt(iniValues.max_file_uploads)
+  return {
+    max_file_size: max_file_size,
+    max_file_uploads: max_file_uploads
+  }
+}


### PR DESCRIPTION
Issue Link:
https://app.asana.com/0/1203011167276215/1203333496313764/f

## Definition of Done
- [x] If at least one of the files is greater than or equal to 2MB, the upload will not proceed and display an error indicating that each file must not be greater than or equal to 2MB.
- [x] If the number of file is greater than or equal to 20, the upload will not proceed and display an error indicating that the user can only upload no more than 20 files at a time.
- [x] Create an endpoint to fetch the PHP configurations for `upload_max_filesize` and `max_file_uploads`. 

## Notes
- This limitation is due to PHP configurations, (http://php.net/manual/en/ini.list.php)
- Based on the documentation, `upload_max_filesize` is `PHP_INI_PERDIR` and `max_file_uploads` is `PHP_INI_SYSTEM`, meaning these configurations can only be set in `php.ini` or `httpd.conf`, (https://www.php.net/manual/en/configuration.changes.modes.php)
- The error message will change based on the indicated PHP configurations of the server.

## Pre-condition
- Go to files section, and open the file upload modal by clicking the upload files button.
- For the first condition, upload a file that is greater than 2MB, the upload must not proceed and must inform the user of this limitation.
- For the next one, upload more than 20 files, the upload must not proceed and must inform the user of this limitation.

## Expected Output
- the upload must not proceed and must inform the user that each files must not be greater than 2MB.
- the upload must not proceed and must inform the user that a user can only upload not greater than 20 files at a time.

## Screenshot/Recordings  

https://user-images.githubusercontent.com/109291819/200998659-f22e9718-4306-47d8-a388-8ca8015f6e37.mp4

