### PR TITLE
[654] - [BugTask] Should scroll down after a new message is sent in the Thread Section

### DIFF
--- a/client/src/components/molecules/ChatList/EditMessageDialog.tsx
+++ b/client/src/components/molecules/ChatList/EditMessageDialog.tsx
@@ -12,7 +12,7 @@ import { ERROR_MESSAGE } from '~/utils/messages'
 import { Spinner } from '~/shared/icons/SpinnerIcon'
 import { updateMessage } from '~/redux/chat/chatSlice'
 import { useAppDispatch } from '~/hooks/reduxSelector'
-import DialogBox from '~/components/templates/DialogBox'
+import DialogTemplate from '~/components/templates/DialogTemplate'
 
 type Props = {
   isOpen: boolean
@@ -66,11 +66,11 @@ const EditMessageDialog: FC<Props> = ({ isOpen, closeModal, chat }): JSX.Element
   }
 
   return (
-    <DialogBox isOpen={isOpen} closeModal={closeModal} bodyClass="px-0 -my-20">
+    <DialogTemplate isOpen={isOpen} closeModal={closeModal}>
       <form
         onSubmit={handleSubmit(handleUpdateMessage)}
         onKeyDown={checkKeyDown}
-        className="relative -mt-4 mb-10"
+        className="relative rounded-xl bg-white"
       >
         <input {...register('id')} hidden type="text" />
         <Controller
@@ -93,13 +93,13 @@ const EditMessageDialog: FC<Props> = ({ isOpen, closeModal, chat }): JSX.Element
         />
         <button
           type="submit"
-          className="absolute top-0.5 right-0 py-3.5 px-4 outline-none"
+          className="absolute top-2 right-2 bg-[#f8fafc] py-2 px-2 outline-none"
           disabled={!isValid}
         >
           <SubmitButton isLoading={isLoading} isValid={isValid} />
         </button>
       </form>
-    </DialogBox>
+    </DialogTemplate>
   )
 }
 

--- a/client/src/components/molecules/ThreadList/EditMessageThreadDialog.tsx
+++ b/client/src/components/molecules/ThreadList/EditMessageThreadDialog.tsx
@@ -1,6 +1,6 @@
 import ReactMde from 'react-mde'
 import toast from 'react-hot-toast'
-import { FC, useState } from 'react'
+import { FC, Fragment, useState } from 'react'
 import { Controller, useForm } from 'react-hook-form'
 
 import { useRouter } from 'next/router'
@@ -12,7 +12,8 @@ import { ERROR_MESSAGE } from '~/utils/messages'
 import { Spinner } from '~/shared/icons/SpinnerIcon'
 import { updateThread } from '~/redux/chat/chatSlice'
 import { useAppDispatch } from '~/hooks/reduxSelector'
-import DialogBox from '~/components/templates/DialogBox'
+import { Dialog, Transition } from '@headlessui/react'
+import DialogTemplate from '~/components/templates/DialogTemplate'
 
 type Props = {
   isOpen: boolean
@@ -66,11 +67,11 @@ const EditMessageThreadDialog: FC<Props> = ({ isOpen, closeModal, chat }): JSX.E
   }
 
   return (
-    <DialogBox isOpen={isOpen} closeModal={closeModal} bodyClass="px-0 -my-20">
+    <DialogTemplate isOpen={isOpen} closeModal={closeModal}>
       <form
         onSubmit={handleSubmit(handleUpdateMessage)}
         onKeyDown={checkKeyDown}
-        className="relative -mt-4 mb-10"
+        className="relative rounded-xl bg-white"
       >
         <input {...register('id')} hidden type="text" />
         <Controller
@@ -93,13 +94,13 @@ const EditMessageThreadDialog: FC<Props> = ({ isOpen, closeModal, chat }): JSX.E
         />
         <button
           type="submit"
-          className="absolute top-0.5 right-0 py-3.5 px-4 outline-none"
+          className="absolute top-2 right-2 bg-[#f8fafc] py-2 px-2 outline-none"
           disabled={!isValid}
         >
           <SubmitButton isLoading={isLoading} isValid={isValid} />
         </button>
       </form>
-    </DialogBox>
+    </DialogTemplate>
   )
 }
 

--- a/client/src/components/molecules/ThreadList/index.tsx
+++ b/client/src/components/molecules/ThreadList/index.tsx
@@ -10,7 +10,6 @@ import handleImageError from '~/helpers/handleImageError'
 import ThreadOptionDropdown from '../ThreadOptionDropdown'
 import ChatThreadEditor from '../ChatEditor/ChatThreadEditor'
 import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
-import toast from 'react-hot-toast'
 import { NOT_FOUND } from '~/utils/constants'
 
 const ThreadList: FC = (): JSX.Element => {
@@ -18,6 +17,7 @@ const ThreadList: FC = (): JSX.Element => {
   const dispatch = useAppDispatch()
   const { id, chat_id } = router.query
   const messageRef = useRef<HTMLDivElement>(null)
+  const threadMessageRef = useRef<HTMLDivElement>(null)
   const [isLoading, setIsLoading] = useState<boolean>(false)
   const { user: author } = useAppSelector((state) => state.auth)
   const { message, isDoneSendingThreadMessage } = useAppSelector((state) => state.chat)
@@ -35,6 +35,16 @@ const ThreadList: FC = (): JSX.Element => {
       onLoad()
     }
   }, [chat_id])
+
+  useEffect(() => {
+    if (threadMessageRef.current) {
+      threadMessageRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+        inline: 'nearest'
+      })
+    }
+  }, [message])
 
   return (
     <>
@@ -131,7 +141,9 @@ const ThreadList: FC = (): JSX.Element => {
           </>
         )}
       </div>
-      <div className="px-4 py-2">{!isLoading ? <ChatThreadEditor /> : null}</div>
+      <div className="px-4 py-2" ref={threadMessageRef}>
+        {!isLoading ? <ChatThreadEditor /> : null}
+      </div>
     </>
   )
 }

--- a/client/src/components/organisms/ThreadDrawer/index.tsx
+++ b/client/src/components/organisms/ThreadDrawer/index.tsx
@@ -3,7 +3,7 @@ import { Hash, X } from 'react-feather'
 import { useRouter } from 'next/router'
 import ReactTooltip from 'react-tooltip'
 import ReactMarkdown from 'react-markdown'
-import React, { FC, useEffect, useState } from 'react'
+import React, { FC, useEffect, useRef, useState } from 'react'
 
 import { Spinner } from '~/shared/icons/SpinnerIcon'
 import { showMessage } from '~/redux/chat/chatSlice'
@@ -13,7 +13,9 @@ import ThreadOptionDropdown from '~/components/molecules/ThreadOptionDropdown'
 import ChatThreadEditor from '~/components/molecules/ChatEditor/ChatThreadEditor'
 import { NOT_FOUND } from '~/utils/constants'
 
-const ThreadSlider: FC = (): JSX.Element => {
+const ThreadDrawer: FC = (): JSX.Element => {
+  const drawerThredRef = useRef<HTMLDivElement>(null)
+
   const {
     overviewProject: { title }
   } = useAppSelector((state) => state.project)
@@ -40,6 +42,16 @@ const ThreadSlider: FC = (): JSX.Element => {
     }
   }, [chat_id])
 
+  useEffect(() => {
+    if (drawerThredRef.current) {
+      drawerThredRef.current.scrollIntoView({
+        behavior: 'smooth',
+        block: 'end',
+        inline: 'nearest'
+      })
+    }
+  }, [message])
+
   return (
     <>
       {chat_id && (
@@ -50,7 +62,7 @@ const ThreadSlider: FC = (): JSX.Element => {
       )}
       <section
         className={`
-          fixed right-0 z-20 h-full w-full flex-1 flex-shrink-0 overflow-hidden
+          fixed right-0 z-20 flex h-full w-full flex-1 flex-shrink-0 flex-col overflow-hidden
            bg-white text-slate-900 transition-all duration-300 ease-in-out sm:max-w-[351px] 
           ${chat_id ? 'block translate-x-0 lg:hidden' : 'translate-x-full'}
         `}
@@ -161,7 +173,7 @@ const ThreadSlider: FC = (): JSX.Element => {
               )}
             </>
           )}
-          <div className="px-4 py-2 pb-[90px]">
+          <div className="px-4 py-2" ref={drawerThredRef}>
             <ChatThreadEditor />
           </div>
         </main>
@@ -190,4 +202,4 @@ const Divider = ({ threadCount }: DividerProps) => {
   )
 }
 
-export default ThreadSlider
+export default ThreadDrawer

--- a/client/src/components/templates/DialogTemplate/index.tsx
+++ b/client/src/components/templates/DialogTemplate/index.tsx
@@ -1,0 +1,45 @@
+import React, { Fragment, FC, ReactNode } from 'react'
+import { Dialog, Transition } from '@headlessui/react'
+
+type Props = {
+  isOpen: boolean
+  closeModal: () => void
+  children: ReactNode
+}
+
+const DialogTemplate: FC<Props> = ({ isOpen, closeModal, children }: Props): JSX.Element => {
+  return (
+    <Transition appear show={isOpen} as={Fragment}>
+      <Dialog as="div" className="relative z-50" onClose={closeModal}>
+        <Transition.Child
+          as={Fragment}
+          enter="ease-out duration-300"
+          enterFrom="opacity-0"
+          enterTo="opacity-100"
+          leave="ease-in duration-200"
+          leaveFrom="opacity-100"
+          leaveTo="opacity-0"
+        >
+          <div className="fixed inset-0 bg-slate-900 bg-opacity-50" />
+        </Transition.Child>
+        <div className="fixed inset-0 overflow-y-auto">
+          <div className="flex min-h-full items-center justify-center p-4 text-center">
+            <Transition.Child
+              as={Fragment}
+              enter="ease-out duration-300"
+              enterFrom="opacity-0 scale-95"
+              enterTo="opacity-100 scale-100"
+              leave="ease-in duration-200"
+              leaveFrom="opacity-100 scale-100"
+              leaveTo="opacity-0 scale-95"
+            >
+              <Dialog.Panel>{children}</Dialog.Panel>
+            </Transition.Child>
+          </div>
+        </div>
+      </Dialog>
+    </Transition>
+  )
+}
+
+export default DialogTemplate

--- a/client/src/pages/team/[id]/chat.tsx
+++ b/client/src/pages/team/[id]/chat.tsx
@@ -15,6 +15,7 @@ import { useAppDispatch, useAppSelector } from '~/hooks/reduxSelector'
 
 const Chat: NextPage = (): JSX.Element => {
   const router = useRouter()
+
   const { id, chat_id } = router.query
   useChatPusher()
 
@@ -42,7 +43,7 @@ const Chat: NextPage = (): JSX.Element => {
           {chat_id ? (
             <section
               className={`
-                default-scrollbar flex h-screen w-[350px] flex-shrink-0 flex-col 
+                default-scrollbar flex h-full w-[350px] flex-shrink-0 flex-col 
                 overflow-y-auto scrollbar-thumb-slate-400
               `}
             >


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203308773766654/f

## Definition of Done
- [x] Thread List Chat Data will scroll down when there is new data coming
- [x] Applied `useRef` hook to prevent the thread data to persist in the bottom area
- [x] CRUD Chat Operation works perfectly with pusher service

## Notes
- THE DRAWER AUTO SCROLL TO BOTTOM IN MOBILE THREAD SIZE IS STILL NOT WORKING!!

## Pre-condition
- yarn dev || npm run start
- Go to the chat page `/teams/${id}/chat` and click the reply to thread button

## Expected Output
- Thread list chat should automatically scroll down to bottom when data getting long

## Screenshots/Recordings
[chat.webm](https://user-images.githubusercontent.com/108642414/202418291-e700fbaa-18a5-4fb4-8a84-0f32d46f777f.webm)
