### PR TITLE
[018] - [BugTask] Create project setting seeders for old data

### DIFF
--- a/api/app/Utils/ProjectSettingUtils.php
+++ b/api/app/Utils/ProjectSettingUtils.php
@@ -1,0 +1,19 @@
+<?php
+
+namespace App\Utils;
+
+use App\Enums\ProjectSettingsEnum;
+use App\Models\Project;
+use App\Models\ProjectSetting;
+
+class ProjectSettingUtils
+{
+  static public function nudgeSetting()
+  {
+    $settingIDs = ProjectSetting::all()->pluck('project_id');
+    $projectIDs = Project::whereNotIn('id', $settingIDs)->pluck('id');
+    return collect($projectIDs)->map(function ($id) {
+      return ['project_id' => $id, 'setting' => ProjectSettingsEnum::MUTE_NUDGE->toString(), 'status' => false];
+    })->toArray();
+  }
+}

--- a/api/database/migrations/2022_11_04_052402_create_github_webhook_calls_table.php
+++ b/api/database/migrations/2022_11_04_052402_create_github_webhook_calls_table.php
@@ -2,21 +2,26 @@
 
 use Illuminate\Database\Schema\Blueprint;
 use Illuminate\Database\Migrations\Migration;
+use Illuminate\Support\Facades\Schema;
 
 return new class extends Migration
 {
-    public function up()
-    {
-        Schema::create('github_webhook_calls', function (Blueprint $table) {
-            $table->bigIncrements('id');
+  public function up()
+  {
+    Schema::create('github_webhook_calls', function (Blueprint $table) {
+      $table->bigIncrements('id');
 
-            $table->string('url');
-            $table->string('name');
-            $table->json('headers')->nullable();
-            $table->json('payload')->nullable();
-            $table->text('exception')->nullable();
+      $table->string('url');
+      $table->string('name');
+      $table->json('headers')->nullable();
+      $table->json('payload')->nullable();
+      $table->text('exception')->nullable();
 
-            $table->timestamps();
-        });
-    }
+      $table->timestamps();
+    });
+  }
+  public function down()
+  {
+    Schema::dropIfExists('github_webhook_calls');
+  }
 };

--- a/api/database/seeders/ProjectSettingSeeder.php
+++ b/api/database/seeders/ProjectSettingSeeder.php
@@ -1,0 +1,20 @@
+<?php
+
+namespace Database\Seeders;
+
+use App\Models\ProjectSetting;
+use App\Utils\ProjectSettingUtils;
+use Illuminate\Database\Seeder;
+
+class ProjectSettingSeeder extends Seeder
+{
+  /**
+   * Run the database seeds.
+   *
+   * @return void
+   */
+  public function run()
+  {
+    ProjectSetting::upsert(ProjectSettingUtils::nudgeSetting(), ['project_id'], ['status', 'setting']);
+  }
+}


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203318657030018/f

## Definition of Done
- [x] Added seeders for project setting seeders for old data

## Notes
- Run `php artisan db:seed --class=ProjectSettingSeeder`

## Pre-condition
- Run `php artisan db:seed --class=ProjectSettingSeeder`

## Expected Output
- Should add project setting data for mute nudge on old data

## Screenshots/Recordings
- ![image](https://user-images.githubusercontent.com/110364637/201060841-d576c141-2b3a-4df2-9218-2109549ccbf1.png)

