### PR TITLE
[018-1] - [BugTask] Fix project setting seeders for old data

### DIFF
--- a/api/database/seeders/ProjectSettingSeeder.php
+++ b/api/database/seeders/ProjectSettingSeeder.php
@@ -15,6 +15,9 @@ class ProjectSettingSeeder extends Seeder
    */
   public function run()
   {
-    ProjectSetting::upsert(ProjectSettingUtils::nudgeSetting(), ['project_id'], ['status', 'setting']);
+    $settings = ProjectSettingUtils::nudgeSetting();
+    foreach ($settings as $setting) {
+      ProjectSetting::firstOrCreate($setting);
+    }
   }
 }


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203342388358534/f

## Definition of Done
- [x] Fixed seeders for project setting seeders for old data

## Notes
- Run `php artisan db:seed --class=ProjectSettingSeeder`

## Pre-condition
- Run `php artisan db:seed --class=ProjectSettingSeeder`

## Expected Output
- Should fix project setting data for mute nudge on old data

## Screenshots/Recordings
- ![image](https://user-images.githubusercontent.com/110364637/201060841-d576c141-2b3a-4df2-9218-2109549ccbf1.png)

