### PR TITLE
[443] - [BugTask] CORS issue: Redirect is not allowed for a preflight request fix

### DIFF
--- a/client/src/redux/files/fileService.ts
+++ b/client/src/redux/files/fileService.ts
@@ -8,7 +8,7 @@ const getProjectFiles = async (projectId: number): Promise<Array<ProjectFileType
 }
 
 const getIniValue = async (): Promise<IniValueType> => {
-  const response = await axios.get('/api/ini/')
+  const response = await axios.get('/api/ini')
   return response.data
 }
 


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203349758582443/f

## Definition of Done
- [x] The OPTION request to `/api/ini` route should return 2XX response instead of 3XX.

## Notes
- This fixes the issue with file uploads (unable to upload files).

## Pre-condition
- Try to upload a file. 

## Expected Output
- OPTION request to `/api/ini` route should return 2XX response instead of 3XX

## Screenshots/Recordings
- ![image](https://user-images.githubusercontent.com/109291819/201247193-45361671-b2cb-4181-b0b6-b87e0141b88f.png)

