### PR TITLE
[684] - [BugTask] Disable button on setting repo when input is empty

### DIFF
--- a/client/src/components/organisms/ProjectSettingsModal/index.tsx
+++ b/client/src/components/organisms/ProjectSettingsModal/index.tsx
@@ -114,8 +114,12 @@ const ProjectSettingsModal: FC<Props> = (props): JSX.Element => {
                 />
                 <button
                   onClick={() => handleSubmitProjectRepo()}
-                  disabled={isRepoLoading}
-                  className={`inline-flex cursor-pointer items-center rounded-r-md border border-r-0 border-green-600 bg-green-600 px-3 text-sm hover:bg-green-700 `}
+                  disabled={isRepoLoading || !repo?.length}
+                  className={`inline-flex cursor-pointer items-center rounded-r-md ${
+                    !repo?.length
+                      ? 'border-slate-500 bg-slate-500'
+                      : 'border-green-600 bg-green-600 hover:bg-green-700 '
+                  } border border-r-0   px-3 text-sm `}
                 >
                   {isRepoLoading ? (
                     <Spinner className="h-5 w-5 text-white" />


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203344010476841/f

## Definition of Done
- [x] Save button is disabled when input is empty in the set repository field

## Notes
- None

## Pre-condition
- Open project settings
- Go to Github Tab
- If there is value in repository field, erase it, and click the button next to it
- If there is no value in repository field, click the button next to it

## Expected Output
- [x] Save button should be disabled when input is empty in the set repository field

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/201259846-1aa530c6-1dfa-45a4-ae67-d1623e9f1864.mp4


