### PR TITLE
[670] - [BugTask] Display the name of uploaded/renamed/deleted files

### DIFF
--- a/client/src/components/molecules/FileList/DragFileUploadDialog.tsx
+++ b/client/src/components/molecules/FileList/DragFileUploadDialog.tsx
@@ -29,7 +29,10 @@ const DragFileUploadDialog: FC<Props> = (props): JSX.Element => {
         if (isError) {
           toast.error(`${error.content}`)
         } else {
-          toast.success('File uploaded successfully!')
+          for (let i = 0; i < acceptedFiles.length; i++) {
+            const filename = acceptedFiles[i].name.split('.').slice(0, -1).join('.')
+            toast.success(`${filename} uploaded successfully!`)
+          }
         }
       })
     }

--- a/client/src/components/molecules/FileList/FIleItem.tsx
+++ b/client/src/components/molecules/FileList/FIleItem.tsx
@@ -13,7 +13,7 @@ type Props = {
   file: File
   actions: {
     handleOpenEditModal: (data?: Filename) => void
-    handleDeleteFile: (id: string) => Promise<void>
+    handleDeleteFile: (id: string, fileName: string) => Promise<void>
     handleDownloadFile: (id: string, fileName: string) => Promise<void>
   }
 }
@@ -67,7 +67,7 @@ const FileItem: FC<Props> = (props): JSX.Element => {
             className={`outline-none active:scale-95 ${can?.deleteFile ? '' : 'hidden'}`}
             data-for="actions"
             data-tip="Delete"
-            onClick={() => handleDeleteFile(id)}
+            onClick={() => handleDeleteFile(id, filename)}
           >
             <Trash className="h-4 w-4 md:h-5 md:w-5" />
           </button>

--- a/client/src/components/molecules/FileList/index.tsx
+++ b/client/src/components/molecules/FileList/index.tsx
@@ -16,7 +16,7 @@ type Props = {
   filename: Filename
   actions: {
     handleOpenEditModal: (data?: Filename) => void
-    handleDeleteFile: (id: string) => Promise<void>
+    handleDeleteFile: (id: string, fileName: string) => Promise<void>
     handleUpdateFilename: (data: Filename) => Promise<void>
   }
   isUpdating: boolean

--- a/client/src/pages/team/[id]/files.tsx
+++ b/client/src/pages/team/[id]/files.tsx
@@ -61,7 +61,7 @@ const Files: NextPage = (): JSX.Element => {
    */
   const handleUpdateFilename = async (data: Filename): Promise<void> => {
     useHandleRenameFile(filename.id, data.filename, () => {
-      toast.success('File renamed successfully!')
+      toast.success(`${filename.filename} renamed to ${data.filename}!`)
     })
     handleOpenEditModal(data)
   }
@@ -69,10 +69,11 @@ const Files: NextPage = (): JSX.Element => {
   /*
    * Handle Delete the File
    */
-  const handleDeleteFile = async (id: string): Promise<void> => {
+  const handleDeleteFile = async (id: string, fileName: string): Promise<void> => {
     DeleteConfirmModal(() => {
       useHandleDeleteFile(id, () => {
-        toast.success('File deleted successfully!')
+        const name = fileName.split('.').slice(0, -1).join('.')
+        toast.success(`${name} deleted!`)
       })
     })
   }
@@ -168,7 +169,10 @@ const FileHeader = (props: FileHeaderProps): JSX.Element => {
         if (isError) {
           toast.error(`${error.content}`)
         } else {
-          toast.success('File uploaded successfully!')
+          for (let i = 0; i < fileUploaded.length; i++) {
+            const filename = fileUploaded[i].name.split('.').slice(0, -1).join('.')
+            toast.success(`${filename} uploaded successfully!`)
+          }
         }
         e.target.value = ''
       })


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203349758582443/f

## Definition of Done
- [x] Display the name of uploaded file
- [x] Display the name of file before renaming and after renaming
- [x] Display the name of deleted file  
- [x] Fixed error toasts when uploading, renaming and deleting files.

## Notes
- None.

## Pre-condition
- Try to upload a file to check if the name of the uploaded file is displayed.
- Try to rename the file to check if the name of file before and after renaming is displayed.
- Try to delete the file to check if the name of file being deleted is displayed. 
- Try to disable server then perform uploading, renaming and deleting to see if error message is displayed.

## Expected Output
- The toast should display the name of uploaded files
- The toast should display the name of file before and after renaming
- The toast should display the name of deleted file

## Screenshots/Recordings


https://user-images.githubusercontent.com/109291819/201581600-caabfeb3-308f-4968-9e46-9c6b2c311a34.mp4


