### PR TITLE
[670] - [BugTask] Display the name of uploaded/renamed/deleted files

### DIFF
--- a/client/src/components/molecules/FileList/DragFileUploadDialog.tsx
+++ b/client/src/components/molecules/FileList/DragFileUploadDialog.tsx
@@ -29,7 +29,11 @@ const DragFileUploadDialog: FC<Props> = (props): JSX.Element => {
         if (isError) {
           toast.error(`${error.content}`)
         } else {
-          toast.success('File uploaded successfully!')
+          Object.entries(acceptedFiles).forEach((entry) => {
+            const [_, value] = entry
+            const filename = value.name.split('.').slice(0, -1).join('.')
+            toast.success(`${filename} uploaded successfully!`)
+          })
         }
       })
     }

--- a/client/src/components/molecules/FileList/FIleItem.tsx
+++ b/client/src/components/molecules/FileList/FIleItem.tsx
@@ -13,7 +13,7 @@ type Props = {
   file: File
   actions: {
     handleOpenEditModal: (data?: Filename) => void
-    handleDeleteFile: (id: string) => Promise<void>
+    handleDeleteFile: (id: string, fileName: string) => Promise<void>
     handleDownloadFile: (id: string, fileName: string) => Promise<void>
   }
 }
@@ -67,7 +67,7 @@ const FileItem: FC<Props> = (props): JSX.Element => {
             className={`outline-none active:scale-95 ${can?.deleteFile ? '' : 'hidden'}`}
             data-for="actions"
             data-tip="Delete"
-            onClick={() => handleDeleteFile(id)}
+            onClick={() => handleDeleteFile(id, filename)}
           >
             <Trash className="h-4 w-4 md:h-5 md:w-5" />
           </button>

--- a/client/src/components/molecules/FileList/index.tsx
+++ b/client/src/components/molecules/FileList/index.tsx
@@ -16,7 +16,7 @@ type Props = {
   filename: Filename
   actions: {
     handleOpenEditModal: (data?: Filename) => void
-    handleDeleteFile: (id: string) => Promise<void>
+    handleDeleteFile: (id: string, fileName: string) => Promise<void>
     handleUpdateFilename: (data: Filename) => Promise<void>
   }
   isUpdating: boolean

--- a/client/src/pages/team/[id]/files.tsx
+++ b/client/src/pages/team/[id]/files.tsx
@@ -26,6 +26,7 @@ const Files: NextPage = (): JSX.Element => {
   const [pageNumber, setPageNumber] = useState<number>(0)
   const [isOpen, setIsOpen] = useState<boolean>(false)
   const [isOpenDragUpload, setIsOpenDragUpload] = useState<boolean>(false)
+  const { error, isError } = useAppSelector((state) => state.file)
   /*
    * This will partially store the id and filename in modal
    */
@@ -61,7 +62,11 @@ const Files: NextPage = (): JSX.Element => {
    */
   const handleUpdateFilename = async (data: Filename): Promise<void> => {
     useHandleRenameFile(filename.id, data.filename, () => {
-      toast.success('File renamed successfully!')
+      if (isError) {
+        toast.error(`${filename.filename} renaming to ${data.filename} failed! ${error.content}`)
+      } else {
+        toast.success(`${filename.filename} renamed to ${data.filename}!`)
+      }
     })
     handleOpenEditModal(data)
   }
@@ -69,10 +74,15 @@ const Files: NextPage = (): JSX.Element => {
   /*
    * Handle Delete the File
    */
-  const handleDeleteFile = async (id: string): Promise<void> => {
+  const handleDeleteFile = async (id: string, fileName: string): Promise<void> => {
     DeleteConfirmModal(() => {
       useHandleDeleteFile(id, () => {
-        toast.success('File deleted successfully!')
+        const name = fileName.split('.').slice(0, -1).join('.')
+        if (isError) {
+          toast.error(`${name} failed to delete! ${error.content}`)
+        } else {
+          toast.success(`${name} deleted!`)
+        }
       })
     })
   }
@@ -168,7 +178,11 @@ const FileHeader = (props: FileHeaderProps): JSX.Element => {
         if (isError) {
           toast.error(`${error.content}`)
         } else {
-          toast.success('File uploaded successfully!')
+          Object.entries(fileUploaded).forEach((entry) => {
+            const [_, value] = entry
+            const filename = value.name.split('.').slice(0, -1).join('.')
+            toast.success(`${filename} uploaded successfully!`)
+          })
         }
         e.target.value = ''
       })

--- a/client/src/redux/files/fileService.ts
+++ b/client/src/redux/files/fileService.ts
@@ -16,7 +16,7 @@ const getProjectFile = async (projectId: number, fileId: string): Promise<Blob |
   const response = await axios.get(`/api/project/${projectId}/file/${fileId}`, {
     responseType: 'blob'
   })
-  return response.data
+  return response
 }
 
 const addProjectFile = async (projectId: number, file: FileList): Promise<string> => {

--- a/client/src/redux/files/fileSlice.ts
+++ b/client/src/redux/files/fileSlice.ts
@@ -101,6 +101,22 @@ export const deleteProjectFile = createAsyncThunk(
   }
 )
 
+export const downloadProjectFile = createAsyncThunk(
+  'file/downloadProjectFile',
+  async (payload: { projectId: number; fileId: string }, thunkAPI) => {
+    try {
+      const response = await fileService.getProjectFile(payload.projectId, payload.fileId)
+      if (response) {
+        const files = await fileService.getProjectFiles(payload.projectId)
+        const formattedFiles = formatFiles(files)
+        return formattedFiles
+      }
+    } catch (error) {
+      return thunkAPI.rejectWithValue(catchError(error))
+    }
+  }
+)
+
 export const fileSlice = createSlice({
   name: 'projectFiles',
   initialState,
@@ -188,6 +204,19 @@ export const fileSlice = createSlice({
         state.files = action.payload
       })
       .addCase(deleteProjectFile.rejected, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isError = true
+        state.error = action.payload
+      })
+      .addCase(downloadProjectFile.pending, (state) => {
+        state.isLoading = true
+      })
+      .addCase(downloadProjectFile.fulfilled, (state, action: PayloadAction<any>) => {
+        state.isLoading = false
+        state.isSuccess = true
+        state.files = action.payload
+      })
+      .addCase(downloadProjectFile.rejected, (state, action: PayloadAction<any>) => {
         state.isLoading = false
         state.isError = true
         state.error = action.payload


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203349758582443/f

## Definition of Done
- [x] Display the name of uploaded file
- [x] Display the name of file before renaming and after renaming
- [x] Display the name of deleted file  
- [x] Fixed error toasts when uploading, renaming and deleting files.

## Notes
- None.

## Pre-condition
- Try to upload a file to check if the name of the uploaded file is displayed.
- Try to rename the file to check if the name of file before and after renaming is displayed.
- Try to delete the file to check if the name of file being deleted is displayed. 
- Try to disable server then perform uploading, renaming and deleting to see if error message is displayed.

## Expected Output
- The toast should display the name of uploaded files
- The toast should display the name of file before and after renaming
- The toast should display the name of deleted file

## Screenshots/Recordings

### Success toasts

https://user-images.githubusercontent.com/109291819/201581600-caabfeb3-308f-4968-9e46-9c6b2c311a34.mp4

### Error toasts

https://user-images.githubusercontent.com/109291819/201631360-ec1252ec-2f9b-46d5-9d9d-f15bf99c17fb.mp4




