### PR TITLE
[850] - [BugTask] Disable remove button in the task slider when task is removed

### DIFF
--- a/client/src/components/organisms/TaskSlider/index.tsx
+++ b/client/src/components/organisms/TaskSlider/index.tsx
@@ -404,9 +404,12 @@ const TaskSlider: FC<Props> = (props): JSX.Element => {
                         >
                           <Menu.Item>
                             <button
+                              disabled={deleteTask}
                               onClick={handleRemoveTask}
                               className={classNames(
-                                'flex w-full items-center space-x-3 py-2 px-4 font-medium text-rose-600',
+                                `${
+                                  deleteTask && 'cursor-not-allowed'
+                                } flex w-full items-center space-x-3 py-2 px-4 font-medium text-rose-600`,
                                 'text-sm transition duration-150 ease-in-out hover:bg-rose-100 active:bg-rose-600 active:text-white'
                               )}
                             >


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203359633989850/f

## Definition of Done
- [x] The remove button should be disabled after the task is removed in the task slider

## Notes
- None

## Pre-condition
- Go to projects
- Go to boards
- Choose a task then open the slider
- Delete the task

## Expected Output
- [x] Should disable remove button in the task slider when task is removed

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/201820891-766ea528-1b7a-4ced-90f7-0c86ea88173a.mp4

