### PR TITLE
[865] - [BugTask] Redirect to 404 when task is not found

### DIFF
--- a/client/src/components/molecules/NotificationPopover/index.tsx
+++ b/client/src/components/molecules/NotificationPopover/index.tsx
@@ -30,9 +30,7 @@ const NotificationPopover = (): JSX.Element => {
     useMarkReadNotification(notification?.id, notification?.data.project_id)
     if (notification?.data?.type === NotificationTypes.ASSIGN_TASK) {
       callback()
-      router.push(
-        `/team/${notification?.data?.project_id}/board?task_id=${notification?.data?.task?.id}`
-      )
+      window.location.href = `/team/${notification?.data?.project_id}/board?task_id=${notification?.data?.task?.id}`
     }
     if (notification?.data?.type === NotificationTypes.COMMIT) {
       window.open(notification?.data?.commit?.url)

--- a/client/src/pages/notifications/projects/[id].tsx
+++ b/client/src/pages/notifications/projects/[id].tsx
@@ -54,9 +54,7 @@ const Notifications: NextPage = (): JSX.Element => {
   const handleReadNotification = (notification: Notification) => {
     useMarkReadNotification(notification.id, notification.data.project_id)
     if (notification.data.type === NotificationTypes.ASSIGN_TASK) {
-      router.push(
-        `/team/${notification.data.project_id}/board?task_id=${notification.data.task?.id}`
-      )
+      window.location.href = `/team/${notification.data.project_id}/board?task_id=${notification.data.task?.id}`
     }
     if (notification.data.type === NotificationTypes.COMMIT) {
       window.open(notification.data.commit?.url)

--- a/client/src/utils/getServerSideProps.ts
+++ b/client/src/utils/getServerSideProps.ts
@@ -32,7 +32,7 @@ export const signInUpAuthCheck: GetServerSideProps = wrapper.getServerSideProps(
 
 export const authCheck: GetServerSideProps = wrapper.getServerSideProps(
   (store) =>
-    async ({ req, params }) => {
+    async ({ req, params, query }) => {
       const token = req.cookies['token']
       const config = { headers: { Authorization: `Bearer ${token}` } }
 
@@ -45,6 +45,9 @@ export const authCheck: GetServerSideProps = wrapper.getServerSideProps(
           req.url?.includes('board')
         ) {
           await axios.get(`/api/project/${params?.id}/member/${res.data.id}`, config)
+          if (req.url?.includes('board?task_id')) {
+            await axios.get(`/api/project/${params?.id}/task/${query?.task_id}/details`, config)
+          }
         }
       } catch (error: any) {
         if (error.response.status === 404) {


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203368962179865/f

## Definition of Done
- [x] The page should redirect to 404 when the task id inputted on the url does not exist/deleted

## Notes
- None

## Pre-condition
- Go to projects
- Go to boards
- Open a task slider
- Copy the URL and delete the task
- reload the URL/browser

## Expected Output
- [x] Should redirect to 404 if task is is not found/deleted

## Screenshots/Recordings



https://user-images.githubusercontent.com/110364637/201884380-372ed5bc-7b5b-4a61-b6e9-50105924c693.mp4

