### PR TITLE
[254] - [Markup] - Modify Team On-hover style in Overview Page

### DIFF
--- a/client/src/components/molecules/TeamTemplate/index.tsx
+++ b/client/src/components/molecules/TeamTemplate/index.tsx
@@ -1,5 +1,6 @@
 import React, { Fragment } from 'react'
 import { useRouter } from 'next/router'
+import { ChevronDown } from 'react-feather'
 import { Menu, Transition } from '@headlessui/react'
 
 import {
@@ -67,28 +68,36 @@ const TeamTemplate = ({ data, callBack, teams, loadingState }: any) => {
         <Menu as="div" className="relative inline-block text-left">
           <div>
             <Menu.Button disabled={!can?.removeTeam && !can?.editTeam}>
-              <div
-                onClick={() => dispatch(setRemoveTeamID({ teamID, projectID }))}
-                className="flex w-[200px] items-center gap-2 truncate mobile:!w-full"
-              >
-                <div className="flex max-h-[44px] max-w-[44px] items-center justify-center rounded-full border">
-                  <img
-                    src={icon?.url}
-                    onError={(e) => handleImageError(e, dummyTeamIcon[7])}
-                    alt="team-icon"
-                    width={100}
-                    height={100}
-                    className="rounded-full"
-                  />
-                </div>
-                <span
-                  data-tip={name.length >= 15 ? name : null}
-                  className="truncate text-base font-semibold"
+              {({ open }) => (
+                <div
+                  onClick={() => dispatch(setRemoveTeamID({ teamID, projectID }))}
+                  className="group flex w-[200px] items-center gap-2 truncate active:scale-95 mobile:!w-full"
                 >
-                  {name}
-                </span>
-                <ReactTooltip />
-              </div>
+                  <div className="flex max-h-[44px] max-w-[44px] items-center justify-center rounded-full border">
+                    <img
+                      src={icon?.url}
+                      onError={(e) => handleImageError(e, dummyTeamIcon[7])}
+                      alt="team-icon"
+                      width={100}
+                      height={100}
+                      className="rounded-full"
+                    />
+                  </div>
+                  <span
+                    data-tip={name.length >= 15 ? name : null}
+                    className="truncate text-base font-semibold"
+                  >
+                    {name}
+                  </span>
+                  <ChevronDown
+                    className={`
+                    h-5 w-5 stroke-2 opacity-0 transition duration-75 ease-in-out group-hover:opacity-100
+                    ${open ? 'opacity-100' : ''}
+                  `}
+                  />
+                  <ReactTooltip />
+                </div>
+              )}
             </Menu.Button>
           </div>
           <Transition

--- a/client/src/components/organisms/SettingsModal/index.tsx
+++ b/client/src/components/organisms/SettingsModal/index.tsx
@@ -1,9 +1,9 @@
 import { X } from 'react-feather'
 import toast from 'react-hot-toast'
-import React, { useEffect, useState } from 'react'
 import ReactTooltip from 'react-tooltip'
 import { useForm } from 'react-hook-form'
 import { yupResolver } from '@hookform/resolvers/yup'
+import React, { useEffect, useState } from 'react'
 
 import {
   uploadPhoto,


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203369142039254/f

## Definition of Done
- [x] Added `ChevronDown Icon` user tries to hover into the Team Button to indicate it is a dropdown option

## Notes 
- None so far

## Pre-condition
- yarn dev
- Go to Overview Page and try to hover the Team Button Section and you'll see the style

## Expected Output
- It should show the modified style of Team Button ChevronIcon during hover state 

## Screenshot
[team on-hover.webm](https://user-images.githubusercontent.com/108642414/202059869-fe2af40a-b534-4019-9a36-e77e99eed5b6.webm)
