### PR TITLE
[617] - [FE] Implement Mark As All Read Notifications Functionality

### DIFF
--- a/api/app/Http/Controllers/MarkReadNotificationController.php
+++ b/api/app/Http/Controllers/MarkReadNotificationController.php
@@ -1,0 +1,15 @@
+<?php
+
+namespace App\Http\Controllers;
+
+use App\Models\Project;
+use Illuminate\Http\Request;
+
+class MarkReadNotificationController extends Controller
+{
+    public function __invoke(Project $project)
+    {
+        auth()->user()->unreadNotifications()->whereJsonContains('data->project_id', $project->id)->update(['read_at' => now()]);
+        return response()->noContent();
+    }
+}

--- a/api/routes/api.php
+++ b/api/routes/api.php
@@ -5,6 +5,7 @@ use App\Http\Controllers\ProjectMemberStatusController;
 use App\Http\Controllers\UpdateUserSettingsController;
 use App\Http\Controllers\ChangeUserPasswordController;
 use App\Http\Controllers\CompleteTaskController;
+use App\Http\Controllers\MarkReadNotificationController;
 use App\Http\Controllers\NotificationController;
 use App\Http\Controllers\NotificationSeenController;
 use App\Http\Controllers\NudgeMemberController;
@@ -42,50 +43,51 @@ use Illuminate\Support\Facades\Route;
 
 Route::githubWebhooks('github-webhooks');
 Route::group(['middleware' => 'auth:sanctum'], function () {
-  Route::apiResource('project', ProjectController::class);
-  Route::apiResource('project.team', ProjectTeamController::class);
-  Route::apiResource('project.member', ProjectMemberController::class);
-  Route::apiResource('project.section', SectionController::class);
-  Route::apiResource('project.section.task', TaskController::class);
-  Route::apiResource('project.file', ProjectFileController::class);
-  Route::apiResource('notification', NotificationController::class);
-  Route::apiResource('project.message', ProjectMessageController::class);
+    Route::apiResource('project', ProjectController::class);
+    Route::apiResource('project.team', ProjectTeamController::class);
+    Route::apiResource('project.member', ProjectMemberController::class);
+    Route::apiResource('project.section', SectionController::class);
+    Route::apiResource('project.section.task', TaskController::class);
+    Route::apiResource('project.file', ProjectFileController::class);
+    Route::apiResource('notification', NotificationController::class);
+    Route::apiResource('project.message', ProjectMessageController::class);
 
-  Route::group(['prefix' => 'ini'], function () {
-    Route::get('/', function () {
-      return ['upload_max_filesize' => ini_get('upload_max_filesize'), 'max_file_uploads' => ini_get('max_file_uploads')];
+    Route::group(['prefix' => 'ini'], function () {
+        Route::get('/', function () {
+            return ['upload_max_filesize' => ini_get('upload_max_filesize'), 'max_file_uploads' => ini_get('max_file_uploads')];
+        });
     });
-  });
 
 
-  Route::group(['prefix' => 'project'], function () {
-    Route::put('/{project}/change-settings', [ProjectSettingController::class, 'update']);
-    Route::put('/{project}/repository', [ProjectRepositoryController::class, 'update']);
-    Route::put('/{project}/project-status', [ProjectStatusController::class, 'update']);
-    Route::delete('/{project}/archive', [ArchiveProjectController::class, 'destroy']);
-    Route::put('/{project}/un-archive', [ArchiveProjectController::class, 'update']);
-    Route::delete('/{project}/leave', [ProjectMemberStatusController::class, 'destroy']);
-    Route::post('/{project}/team-lead', [ProjectMemberStatusController::class, 'store']);
-    Route::put('/{project}/mvp', [ProjectMemberStatusController::class, 'update']);
-    Route::put('/{project}/task/{task}/details', [TaskDetailsController::class, 'update']);
-    Route::get('/{project}/task/{task}/details', [TaskDetailsController::class, 'show']);
-    Route::put('/{project}/task/{task}/complete', [CompleteTaskController::class, 'update']);
-    Route::put('/{project}/task/{task}/due-date', [TaskDueDateController::class, 'update']);
-    Route::put('/{project}/task/{task}/assign', [TaskAssignmentController::class, 'update']);
-    Route::put('/{project}/section/{section}/reorder-tasks', [TaskReorderController::class, 'update']);
-    Route::get('/{project}/member/{member}/nudge-member', [NudgeMemberController::class, 'show']);
-    Route::put('/{project}/task/position', [TaskPositionController::class, 'update']);
-    Route::put('/{project}/task/{task}/move-section', [TaskSectionController::class, 'update']);
-    Route::put('/notification/seen', [NotificationSeenController::class, 'update']);
-    Route::apiResource('/message.thread', ProjectMessageThreadController::class)->except(['show']);
-  });
+    Route::group(['prefix' => 'project'], function () {
+        Route::put('/{project}/change-settings', [ProjectSettingController::class, 'update']);
+        Route::put('/{project}/repository', [ProjectRepositoryController::class, 'update']);
+        Route::put('/{project}/project-status', [ProjectStatusController::class, 'update']);
+        Route::delete('/{project}/archive', [ArchiveProjectController::class, 'destroy']);
+        Route::put('/{project}/un-archive', [ArchiveProjectController::class, 'update']);
+        Route::delete('/{project}/leave', [ProjectMemberStatusController::class, 'destroy']);
+        Route::post('/{project}/team-lead', [ProjectMemberStatusController::class, 'store']);
+        Route::put('/{project}/mvp', [ProjectMemberStatusController::class, 'update']);
+        Route::put('/{project}/task/{task}/details', [TaskDetailsController::class, 'update']);
+        Route::get('/{project}/task/{task}/details', [TaskDetailsController::class, 'show']);
+        Route::put('/{project}/task/{task}/complete', [CompleteTaskController::class, 'update']);
+        Route::put('/{project}/task/{task}/due-date', [TaskDueDateController::class, 'update']);
+        Route::put('/{project}/task/{task}/assign', [TaskAssignmentController::class, 'update']);
+        Route::put('/{project}/section/{section}/reorder-tasks', [TaskReorderController::class, 'update']);
+        Route::get('/{project}/member/{member}/nudge-member', [NudgeMemberController::class, 'show']);
+        Route::put('/{project}/task/position', [TaskPositionController::class, 'update']);
+        Route::put('/{project}/task/{task}/move-section', [TaskSectionController::class, 'update']);
+        Route::put('/notification/seen', [NotificationSeenController::class, 'update']);
+        Route::put('/{project}/notification/mark-read', MarkReadNotificationController::class);
+        Route::apiResource('/message.thread', ProjectMessageThreadController::class)->except(['show']);
+    });
 
-  Route::group(['prefix' => 'user'], function () {
-    Route::put('change-password', [ChangeUserPasswordController::class, 'update']);
-    Route::apiResource('setting', UpdateUserSettingsController::class)->only(['store', 'update', 'destroy']);
-    Route::put('change-details', [UserController::class, 'update']);
-    Route::get('/', [UserController::class, 'index']);
-  });
+    Route::group(['prefix' => 'user'], function () {
+        Route::put('change-password', [ChangeUserPasswordController::class, 'update']);
+        Route::apiResource('setting', UpdateUserSettingsController::class)->only(['store', 'update', 'destroy']);
+        Route::put('change-details', [UserController::class, 'update']);
+        Route::get('/', [UserController::class, 'index']);
+    });
 });
 
 require __DIR__ . '/auth.php';

--- a/client/src/components/molecules/NotificationPopover/index.tsx
+++ b/client/src/components/molecules/NotificationPopover/index.tsx
@@ -13,7 +13,8 @@ import { formatMoment } from '~/utils/formatMoment'
 import handleImageError from '~/helpers/handleImageError'
 import { Notification } from '~/shared/interfaces'
 import { NotificationTypes } from '~/utils/constants'
-import { Spinner } from '~/shared/icons/SpinnerIcon'
+import ImageSkeleton from '~/components/atoms/Skeletons/ImageSkeleton'
+import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 
 const NotificationPopover = (): JSX.Element => {
   const router = useRouter()
@@ -47,6 +48,18 @@ const NotificationPopover = (): JSX.Element => {
     router.push(`/notifications/projects/${sidebarProject[0]?.id}?type=all`)
   }
 
+  const loadingNotification = () => (
+    <div key={Math.random()} className="mx-2 mt-1 flex items-center gap-2">
+      <div>
+        <ImageSkeleton className="max-h-[33px] max-w-[33px] rounded-full " />
+      </div>
+      <div className="flex flex-col items-start justify-start">
+        <LineSkeleton className="mt-[10px] w-48" />
+        <LineSkeleton className="w-40" />
+      </div>
+    </div>
+  )
+
   return (
     <Popover css={styles.popover}>
       {({ open, close }) => (
@@ -67,10 +80,7 @@ const NotificationPopover = (): JSX.Element => {
               </header>
               <main css={styles.main} className="scroll-show-on-hover default-scrollbar">
                 {isPopoverLoading ? (
-                  <div className="m-auto mt-2 flex items-center justify-center">
-                    <Spinner className="h-5 w-5" />
-                    <span className="ml-1 text-sm"> Loading...</span>
-                  </div>
+                  [...Array(3)].map(() => loadingNotification())
                 ) : notifications.length ? (
                   notifications.map((notification: Notification) => {
                     return (

--- a/client/src/pages/notifications/projects/[id].tsx
+++ b/client/src/pages/notifications/projects/[id].tsx
@@ -1,8 +1,9 @@
 import Link from 'next/link'
 import { NextPage } from 'next'
 import { FC, useEffect, useState } from 'react'
-import { Hash } from 'react-feather'
+import { Check, Hash, MoreHorizontal } from 'react-feather'
 import { NextRouter, useRouter } from 'next/router'
+import { Menu } from '@headlessui/react'
 
 import { globals } from '~/shared/twin/globals.styles'
 import Pagination from '~/components/atoms/Pagination'
@@ -12,6 +13,8 @@ import { useNotificationMethods } from '~/hooks/notificationMethods'
 import LineSkeleton from '~/components/atoms/Skeletons/LineSkeleton'
 import { Notification, SidebarProject } from '~/shared/interfaces'
 import { NotificationTypes } from '~/utils/constants'
+import MenuTransition from '~/components/templates/MenuTransition'
+import { classNames } from '~/helpers/classNames'
 
 const Notifications: NextPage = (): JSX.Element => {
   const router: NextRouter = useRouter()
@@ -22,12 +25,15 @@ const Notifications: NextPage = (): JSX.Element => {
     isSidebarLoading,
     notificationsTable,
     isTableLoading,
+    useSetCurrentID,
     useGetNotificationsTable,
+    useMarkAllReadNotification,
     useMarkReadNotification
   } = useNotificationMethods(parseInt(id as string))
 
   useEffect(() => {
     useGetNotificationsTable(parseInt(id as string), type as string)
+    useSetCurrentID(parseInt(id as string))
   }, [id, type])
 
   /*
@@ -63,6 +69,11 @@ const Notifications: NextPage = (): JSX.Element => {
       window.open(notification.data.pr_details?.url)
     }
   }
+
+  const handleMarkAllReadNotification = () => {
+    useMarkAllReadNotification(parseInt(id as string))
+  }
+
   return (
     <NotificationLayout metaTitle="Notifications">
       <article className="flex h-full min-h-full w-full overflow-hidden text-slate-700">
@@ -136,6 +147,40 @@ const Notifications: NextPage = (): JSX.Element => {
               >
                 Unread
               </button>
+              <Menu as="div" className={`inline-block bg-white text-center`}>
+                {({ open }) => (
+                  <div
+                    className={`${
+                      open && 'bg-slate-100'
+                    } w-10 py-2 outline-none hover:bg-slate-100 md:py-1.5`}
+                  >
+                    <Menu.Button>
+                      <MoreHorizontal className="absolute -mt-4 -ml-3 h-5 w-5" />
+                    </Menu.Button>
+                    <MenuTransition>
+                      <Menu.Items
+                        className={classNames(
+                          'absolute right-6 mt-3 w-44 origin-top-right divide-y divide-gray-200 overflow-hidden md:right-20',
+                          'rounded-md border border-slate-200 bg-white py-1 shadow-xl focus:outline-none'
+                        )}
+                      >
+                        <Menu.Item>
+                          <button
+                            className={classNames(
+                              'flex w-full items-center space-x-3 py-2 px-4 text-sm font-medium text-slate-900',
+                              'transition duration-150 ease-in-out hover:bg-slate-100 active:bg-slate-500 active:text-white'
+                            )}
+                            onClick={handleMarkAllReadNotification}
+                          >
+                            <Check className="mr-2 h-4 w-4" />
+                            Mark all as read
+                          </button>
+                        </Menu.Item>
+                      </Menu.Items>
+                    </MenuTransition>
+                  </div>
+                )}
+              </Menu>
             </div>
           </article>
           <article className="mx-auto flex w-full max-w-7xl flex-1 flex-col justify-between overflow-hidden bg-white px-4 pb-4">

--- a/client/src/redux/notification/notificationSlice.ts
+++ b/client/src/redux/notification/notificationSlice.ts
@@ -1,0 +1,34 @@
+import { createSlice } from '@reduxjs/toolkit'
+
+import { Notification } from '~/shared/interfaces'
+
+type InitialState = {
+  notifications: Array<Notification>
+  notificationsTable: Array<Notification>
+  currentID: number
+}
+
+const initialState: InitialState = {
+  notifications: [],
+  notificationsTable: [],
+  currentID: 0
+}
+
+export const notificationSlice = createSlice({
+  name: 'notification',
+  initialState,
+  reducers: {
+    setNotifications: (state, { payload }) => {
+      state.notifications = payload
+    },
+    setNotificationsTable: (state, { payload }) => {
+      state.notificationsTable = payload
+    },
+    setCurrentID: (state, { payload }) => {
+      state.currentID = payload
+    }
+  }
+})
+
+export const { setNotifications, setNotificationsTable, setCurrentID } = notificationSlice.actions
+export default notificationSlice.reducer

--- a/client/src/redux/store.ts
+++ b/client/src/redux/store.ts
@@ -9,6 +9,7 @@ import memberReducer from './member/memberSlice'
 import taskReducer from './task/taskSlice'
 import fileReducer from './files/fileSlice'
 import chatReducer from './chat/chatSlice'
+import notificationReducer from './notification/notificationSlice'
 
 export const store = configureStore({
   reducer: {
@@ -19,7 +20,8 @@ export const store = configureStore({
     member: memberReducer,
     task: taskReducer,
     file: fileReducer,
-    chat: chatReducer
+    chat: chatReducer,
+    notification: notificationReducer
   }
 })
 


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203405714231617/f

## Definition of Done
- [x] Created popover on the notification page which displays the mark all as read button
- [x] Can now mark all notifications on a certain project to be read 

## Notes
- None

## Pre-condition
- Go to notifications page
- click the three option button popover
- click Mark all as read

## Expected Output
- Should be able to mark all notification of a certain project to be read

## Screenshots/Recordings

https://user-images.githubusercontent.com/110364637/202988341-76ac3f96-1289-49e4-995d-bb54e238f826.mp4




