### PR TITLE
[672] - [BugTask] On the notification page the user can click and see the search modal

### DIFF
--- a/client/src/components/organisms/Header/index.tsx
+++ b/client/src/components/organisms/Header/index.tsx
@@ -5,10 +5,8 @@ import { IoIosMenu } from 'react-icons/io'
 
 import Logo2Icon from '~/shared/icons/Logo2Icon'
 import { styles } from '~/shared/twin/header.styles'
-import { useAppSelector } from '~/hooks/reduxSelector'
 import UserMenuDropDown from '~/components/molecules/UserMenuDropdown'
 import NotificationPopover from '~/components/molecules/NotificationPopover'
-import CommandPallete from '~/components/molecules/CommandPallete'
 
 type Props = {
   actions: {

--- a/client/src/components/templates/NotificationLayout/index.tsx
+++ b/client/src/components/templates/NotificationLayout/index.tsx
@@ -4,6 +4,7 @@ import createPersistedState from 'use-persisted-state'
 
 import Header from '~/components/organisms/Header'
 import { styles } from '~/shared/twin/home-layout.styles'
+import CommandPallete from '~/components/molecules/CommandPallete'
 
 type Props = {
   children: React.ReactNode
@@ -15,17 +16,20 @@ const useSidebarState = createPersistedState<boolean>('sidebarToggle')
 const Layout: React.FC<Props> = ({ children, metaTitle }): JSX.Element => {
   const [isOpenSidebar, setIsOpenSidebar] = useSidebarState(true)
   const [isOpenDrawer, setIsOpenDrawer] = useState<boolean>(false)
+  const [isOpenSearch, setIsOpenSearch] = useState<boolean>(false)
 
-  const handleToggleSidebar = (): void => setIsOpenSidebar(!isOpenSidebar)
   const handleToggleDrawer = (): void => setIsOpenDrawer(!isOpenDrawer)
+  const handleToggleSidebar = (): void => setIsOpenSidebar(!isOpenSidebar)
+  const handleToggleSearch = (): void => setIsOpenSearch(!isOpenSearch)
 
   return (
     <>
       <Head>
         <title key="notifications">{`Slackana | ${metaTitle}`}</title>
       </Head>
+      <CommandPallete isOpen={isOpenSearch} closeModal={handleToggleSearch} />
       <main css={styles.main}>
-        <Header actions={{ handleToggleSidebar, handleToggleDrawer }} />
+        <Header actions={{ handleToggleSidebar, handleToggleDrawer, handleToggleSearch }} />
         <section css={styles.section}>
           <div css={styles.content}>{children}</div>
         </section>


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276287/1203416084889672/f

## Definition of Done
- [x] Added Props of the reusable Header component 

## Pre-condition
- yarn dev

## Expected Output
- It should work the functionality of the search in the notification layout

## Screenshots
[searchdddaadf.webm](https://user-images.githubusercontent.com/108642414/203526802-a1f74562-7d24-4b30-b6da-1dc79dd59731.webm)

