### PR TITLE
[073] - [FE] Apply Lazy Loading in Chat Feature

### DIFF
--- a/api/app/Http/Controllers/ProjectMessageController.php
+++ b/api/app/Http/Controllers/ProjectMessageController.php
@@ -13,12 +13,12 @@ class ProjectMessageController extends Controller
 {
     public function index(Project $project)
     {
-        return ProjectMessageResource::collection($project->messages()->withCount(['thread'])->with(['member.user.avatar', 'thread.member.user.avatar'])->oldest()->get());
+        return ProjectMessageResource::collection(array_reverse($project->messages()->withCount(['thread'])->with(['member.user.avatar'])->latest()->paginate(10)->items()));
     }
 
     public function show(Project $project, ProjectMessage $message)
     {
-        return response()->json($message->displayMessage());
+        return response()->json($message->displayMessageWithThread());
     }
 
     public function store(ProjectMessageRequest $request, Project $project)

--- a/api/app/Models/ProjectMessage.php
+++ b/api/app/Models/ProjectMessage.php
@@ -55,6 +55,11 @@ class ProjectMessage extends Model
 
   public function displayMessage()
   {
+    return new ProjectMessageResource(ProjectMessage::withCount(['thread'])->with(['member.user.avatar'])->findOrFail($this->id));
+  }
+
+  public function displayMessageWithThread()
+  {
     return new ProjectMessageResource(ProjectMessage::withCount(['thread'])->with(['member.user.avatar', 'thread.member.user.avatar'])->findOrFail($this->id));
   }
 }

--- a/api/app/Models/ProjectMessageThread.php
+++ b/api/app/Models/ProjectMessageThread.php
@@ -46,6 +46,6 @@ class ProjectMessageThread extends Model
 
     public function displayThreadMessage()
     {
-        return new ProjectMessageThreadResource(ProjectMessageThread::with('member.user.avatar')->findOrFail($this->id));
+        return new ProjectMessageThreadResource(ProjectMessageThread::with(['member.user.avatar'])->findOrFail($this->id));
     }
 }

--- a/client/src/components/organisms/ThreadDrawer/index.tsx
+++ b/client/src/components/organisms/ThreadDrawer/index.tsx
@@ -115,8 +115,8 @@ const ThreadDrawer: FC = (): JSX.Element => {
                   </section>
                 </main>
               </section>
-              <Divider threadCount={message?.thread?.length} />
-              {!message?.thread?.length ? (
+              <Divider threadCount={message?.threadCount} />
+              {!message?.threadCount ? (
                 <p className="text-center text-sm font-normal text-slate-400">No Threads</p>
               ) : (
                 <>

--- a/client/src/hooks/useChatLazyLoad.ts
+++ b/client/src/hooks/useChatLazyLoad.ts
@@ -1,0 +1,30 @@
+import { useRouter } from 'next/router'
+import { useEffect, useState } from 'react'
+
+import { useAppDispatch } from './reduxSelector'
+import { getMoreMessages } from '~/redux/chat/chatSlice'
+import { AxiosResponseError } from '~/shared/types'
+
+const useChatLazyLoad = () => {
+  const [pageNumber, setPageNumber] = useState<number>(1)
+  const router = useRouter()
+  const { id } = router.query
+  const dispatch = useAppDispatch()
+  const [onLoad, setOnLoad] = useState<boolean>(false)
+
+  const handleOnLoad = () => {
+    if (pageNumber !== 1) {
+      dispatch(getMoreMessages({ projectId: id, pageNumber }))
+    }
+  }
+
+  useEffect(() => {
+    handleOnLoad()
+  }, [pageNumber])
+
+  return {
+    setPageNumber
+  }
+}
+
+export default useChatLazyLoad

--- a/client/src/pages/team/[id]/chat.tsx
+++ b/client/src/pages/team/[id]/chat.tsx
@@ -1,8 +1,8 @@
 import { NextPage } from 'next'
 import { useRouter } from 'next/router'
 import React, { useEffect } from 'react'
-
 import { AlertTriangle } from 'react-feather'
+
 import useChatPusher from '~/hooks/chatPusher'
 import { getMessages } from '~/redux/chat/chatSlice'
 import { Spinner } from '~/shared/icons/SpinnerIcon'
@@ -22,7 +22,7 @@ const Chat: NextPage = (): JSX.Element => {
   const dispatch = useAppDispatch()
 
   useEffect(() => {
-    dispatch(getMessages(id))
+    dispatch(getMessages({ projectId: id }))
   }, [])
 
   return (
@@ -30,8 +30,8 @@ const Chat: NextPage = (): JSX.Element => {
       <div className="flex space-x-0.5 divide-x divide-slate-300 overflow-hidden">
         <section className="flex h-screen flex-1 flex-col">
           <main
-            className={`default-scrollbar flex h-full flex-col justify-between
-             overflow-y-auto scroll-smooth scrollbar-thumb-slate-400`}
+            className={`default-scrollbar flex h-full
+             flex-col justify-between overflow-y-auto`}
           >
             <MainChatContent />
           </main>
@@ -60,7 +60,7 @@ const Chat: NextPage = (): JSX.Element => {
 }
 
 const MainChatContent = () => {
-  const { chats, isLoading, isError } = useAppSelector((state) => state.chat)
+  const { chats, isLoading, isError, isFetchingMoreData } = useAppSelector((state) => state.chat)
   const {
     projectDescription: { title: projectTitle }
   } = useAppSelector((state) => state.project)
@@ -87,7 +87,7 @@ const MainChatContent = () => {
 
   return (
     <>
-      {projectTitle ? (
+      {projectTitle && !isFetchingMoreData ? (
         <h1 className="py-3 text-center text-sm font-medium text-slate-400">{projectTitle}</h1>
       ) : null}
       <ChatList />

--- a/client/src/redux/chat/chatService.ts
+++ b/client/src/redux/chat/chatService.ts
@@ -4,26 +4,35 @@ import {
   Chat,
   DeleteMessageThreadType,
   DeleteMessageType,
+  GetMessageType,
   MessageThreadResponse,
   UpdateMessageThreadType,
   UpdateMessageType
 } from './chatType'
 import { axios } from '~/shared/lib/axios'
 
+/* Chat Messages */
 
-  /* Chat Messages */
-
-const getMessages = async (projectId: number | string): Promise<Chat[]> => {
-  const response = await axios.get(`/api/project/${projectId}/message`)
+const getMessages = async ({ projectId, pageNumber = 1 }: GetMessageType): Promise<Chat[]> => {
+  const response = await axios.get(`/api/project/${projectId}/message`, {
+    params: { page: pageNumber }
+  })
   return response.data
 }
 
-const showMessage = async (projectId: number, messageId: number): Promise<string> => {
+const getMoreMessages = async ({ projectId, pageNumber = 1 }: GetMessageType): Promise<Chat[]> => {
+  const response = await axios.get(`/api/project/${projectId}/message`, {
+    params: { page: pageNumber }
+  })
+  return response.data
+}
+
+const showMessage = async (projectId: number, messageId: number): Promise<Chat> => {
   const response = await axios.get(`/api/project/${projectId}/message/${messageId}`)
   return response.data
 }
 
-const addMessage = async (payload: AddMessageType): Promise<any> => {
+const addMessage = async (payload: AddMessageType): Promise<Chat> => {
   const { projectId, message } = payload
   const response = await axios.post(`/api/project/${projectId}/message`, { message })
   return response.data
@@ -69,8 +78,10 @@ const deleteThread = async (payload: DeleteMessageThreadType): Promise<MessageTh
   return response.data
 }
 
+
 const chatService = {
   getMessages,
+  getMoreMessages,
   showMessage,
   addMessage,
   updateMessage,

--- a/client/src/redux/chat/chatType.ts
+++ b/client/src/redux/chat/chatType.ts
@@ -38,6 +38,12 @@ export type AddMessageType = {
   projectId: string | string[] | undefined
   message: string
 }
+
+export type GetMessageType = {
+  projectId: string | string[] | undefined
+  pageNumber?: number
+}
+
 export type UpdateMessageType = {
   projectId: string | string[] | undefined
   messageId: number

--- a/client/src/utils/constants.ts
+++ b/client/src/utils/constants.ts
@@ -7,3 +7,5 @@ export const NotificationTypes: NotificationConstants = {
 } as const
 
 export const NOT_FOUND = '/404'
+
+export const CHAT_LENGTH = 10


### PR DESCRIPTION
## Issue Link
- https://app.asana.com/0/1203011167276215/1203326954304073/f

## Definition of Done
- [x] Applied Lazy Loading whenever the Project has many messages
- [x] When user scrolls up it will fetch another set history messages 

## Notes
- Removed message threads in the chat list, it causes issues with Pusher since Pusher allows only 10240 bytes of data to be transferred

## Pre-condition
- Go to the project chat sections
- Make sure that project has a lot of conversions to make the functionality work
- Scroll to the top of the page

## Expected Output
- It will fetch a new set previous conversions of the chat

## Screenshots/Recordings
  [lazy-loading](https://user-images.githubusercontent.com/108660012/203909026-c1190a4b-45a3-495e-b79b-960598c0adf8.webm)
